### PR TITLE
fix(scripts): fix sqlite3 issue with windows binary

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -6,6 +6,15 @@ const package = async () => {
   const version = require(path.join(__dirname, '../package.json')).version.replace(/\./g, '_')
 
   try {
+    const platforms = ['darwin', 'win32', 'linux']
+    for (const platform of platforms) {
+      await execute(
+        `./node_modules/.bin/node-pre-gyp install --directory=./node_modules/sqlite3 --target_platform=${platform} --target_arch=x64`,
+        undefined,
+        { silent: true }
+      )
+    }
+
     await execute('cross-env pkg package.json', undefined, { silent: true })
 
     await fse.rename('./bin/messaging-win.exe', `./bin/messaging-v${version}-win-x64.exe`)


### PR DESCRIPTION
This PR fixes an issue where SQLite3 node bindings were not properly configured with Windows and Mac. THe issue was fixed by downloading the bindings before packaging.

Closes MES-1