### PR TITLE
chore(docker): reduce dockerfile resulting image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,10 @@ bin/
 doc
 res
 scripts
+.editorconfig
+.eslintrc.js
+.gitignore
+.prettierrc
+api.rest
+CHANGELOG.md
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13.0
+FROM node:12.13.0-alpine AS build
 
 ADD . /messaging
 
@@ -6,6 +6,17 @@ WORKDIR /messaging
 
 RUN yarn build
 
+FROM node:12.13.0-alpine
+
+COPY --from=build /messaging/dist /messaging/
+COPY --from=build /messaging/package.json /messaging/package.json
+COPY --from=build /messaging/package.json /messaging/yarn.lock
+
+WORKDIR /messaging
+
+RUN yarn --silent --prod
+
 ENV NODE_ENV=production
 
-CMD ["node", "./dist"]
+ENTRYPOINT [ "node" ]
+CMD ["./index.js"]


### PR DESCRIPTION
This PR reduces the docker image size by a considerable amount using multistage builds, only having production dependencies on the resulting image and using Alpine Linux as the base image.

|         | Base Image           | Size  |
| ------------- |:-------------| -----:|
| Before      | node:12.13.0 | 1.34GB |
| After      | node:12.13.0-alpine |  405MB |

Closes MES-2