### PR TITLE
feat(redis): added support to prefix redis channels

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -22,6 +22,7 @@ Environment variables have priority over settings configured in the `config.json
 | CLUSTER_ENABLED   | redis.enabled       | This setting determines if redis is enabled or not. The other redis settings will have no effect if this value is set to false                                                                                                                                                                                                                                                                                                |
 | REDIS_URL         | redis.connection    | Connection string to a redis instance (ex: `redis://login:password@your-redis-host.com:6379`). If you want to configure redis for clustering, you can supply an array of connections instead (ex: `[{"host":"localhost","port":7004},{"host":"localhost","port":7001},{"host":"localhost","port":7002}]`)                                                                                                                     |
 | REDIS_OPTIONS     | redis.options       | Advances options for redis. Refer to the [ioredis documentation](https://github.com/luin/ioredis/blob/master/API.md) (ex: `{"password":"admin123", "connectTimeout": 20000})`                                                                                                                                                                                                                                                 |
+| REDIS_SCOPE       | redis.scope         | Allows to prefix Redis channels and keys when multiple clients uses the same Redis cluster (e.g. `development`, `production`, `server-a`)                                                                                                                                                                                                                                                                                     |
 | SYNC              | sync                | Array of sync requests to be executed when the server starts. This can be used to configure sandboxes, or test clients                                                                                                                                                                                                                                                                                                        |
 | SKIP_LOAD_CONFIG  | none                | If set to `true`, the server will skip loading any config from the `config.json` file                                                                                                                                                                                                                                                                                                                                         |
 | SKIP_LOAD_ENV     | none                | If set to `true`, the server will skip loading any config from the `.env` file                                                                                                                                                                                                                                                                                                                                                |
@@ -45,7 +46,8 @@ Environment variables have priority over settings configured in the `config.json
   "redis": {
     "enabled": true,
     "connection": "redis://user:password@localhost:6379",
-    "options": { "connectTimeout": 20000 }
+    "options": { "connectTimeout": 20000 },
+    "scope": "production"
   },
   "sync": [
     {
@@ -92,5 +94,6 @@ ENCRYPTION_KEY=this+is+a+test+key+ruwy1UMdKwlwo8n412wCek2w=
 CLUSTER_ENABLED=true
 REDIS_URL=redis://user:password@localhost:6379
 REDIS_OPTIONS={"connectTimeout":20000}
+REDIS_SCOPE=production
 SYNC=[{"name":"sandbox","sandbox":true,"channels":{"telegram":{"enabled":true,"botToken":"my-bot-token"}}},{"id":"96af5294-46f1-4a85-a17f-6863fa4d77d7","token":"test-token-123","name":"test","channels":{"twilio":{"enabled":true,"accountSID":"my-account-sid","authToken":"my-auth-token"},"telegram":{"enabled":true,"botToken":"my-bot-token"}},"webhooks":[]}]
 ```

--- a/res/config.json
+++ b/res/config.json
@@ -14,7 +14,8 @@
   "redis": {
     "enabled": false,
     "connection": null,
-    "options": null
+    "options": null,
+    "scope": null
   },
   "sync": [
     {

--- a/src/distributed/redis/config.ts
+++ b/src/distributed/redis/config.ts
@@ -4,4 +4,5 @@ export interface RedisConfig {
   enabled: boolean
   connection: string | ClusterNode[]
   options: RedisOptions | ClusterOptions
+  scope: string
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -9,6 +9,7 @@ export interface MessagingEnv {
   CLUSTER_ENABLED?: string
   REDIS_URL?: string
   REDIS_OPTIONS?: string
+  REDIS_SCOPE?: string
   SYNC?: string
   SKIP_LOAD_CONFIG?: string
   SKIP_LOAD_ENV?: string


### PR DESCRIPTION
This PR adds support for specifying a Redis scope (`REDIS_SCOPE`) which is then used to prefix Redis channels and keys as this prevents messages to be published across every subscribers on a Redis cluster (no matter what DB they subscribed on). See: https://redis.io/topics/pubsub#database-amp-scoping

Closes MES-4