### PR TITLE
chore(dev): uniform logging

### DIFF
--- a/src/channels/base/channel.ts
+++ b/src/channels/base/channel.ts
@@ -1,6 +1,7 @@
 import clc from 'cli-color'
 import { NextFunction, Request, Response, Router } from 'express'
 import Joi from 'joi'
+import yn from 'yn'
 import { App } from '../../app'
 import { uuid } from '../../base/types'
 import { Logger } from '../../logger/types'
@@ -57,11 +58,13 @@ export abstract class Channel<TConduit extends ConduitInstance<any, any>> {
   }
 
   protected printWebhook(route?: string) {
-    this.logger.info(
-      `${clc.bold(this.name.charAt(0).toUpperCase() + this.name.slice(1))}` +
-        `${route ? ' ' + route : ''}` +
-        ` webhook ${clc.blackBright(this.getRoute(route))}`
-    )
+    if (!yn(process.env.SPINNED)) {
+      this.logger.info(
+        `${clc.bold(this.name.charAt(0).toUpperCase() + this.name.slice(1))}` +
+          `${route ? ' ' + route : ''}` +
+          ` webhook ${clc.blackBright(this.getRoute(route))}`
+      )
+    }
   }
 
   abstract createConduit(): TConduit

--- a/src/global.ts
+++ b/src/global.ts
@@ -14,6 +14,7 @@ export interface MessagingEnv {
   SYNC?: string
   SKIP_LOAD_CONFIG?: string
   SKIP_LOAD_ENV?: string
+  SPINNED?: string
 }
 
 declare global {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import clc from 'cli-color'
 import { Express } from 'express'
 import _ from 'lodash'
@@ -57,12 +58,7 @@ export class Launcher {
 
     this.express.listen(port)
 
-    this.logger.info(`Server is listening at: http://localhost:${port}`)
-
-    const externalUrl = process.env.EXTERNAL_URL || this.app.config.current.server?.externalUrl
-    if (externalUrl?.length) {
-      this.logger.info(`Server is exposed at: ${externalUrl}`)
-    }
+    this.logger.info(chalk.gray(`Messaging is listening at: http://localhost:${port}`))
   }
 
   async shutDown(code?: number) {
@@ -78,15 +74,10 @@ export class Launcher {
       const padding = Math.floor((width - text.length) / 2)
       return _.repeat(' ', padding + indent) + text + _.repeat(' ', padding)
     }
-
-    this.logger.info(
-      '========================================\n' +
-        clc.bold(centerText('Botpress Messaging', 40, 33)) +
-        '\n' +
-        clc.blackBright(centerText(`Version ${pkg.version}`, 40, 33)) +
-        '\n' +
-        centerText('========================================', 40, 33)
-    )
+    this.logger.info(chalk`========================================
+    {bold ${centerText('Botpress Messaging', 40, 41)}}
+    {dim ${centerText(`Version ${pkg.version}`, 40, 41)}}
+    ${_.repeat(' ', 41)}========================================`)
   }
 
   private printChannels() {
@@ -105,6 +96,11 @@ export class Launcher {
       }
     }
 
-    this.logger.info(`Using ${clc.bold(enabled)} channels` + enabledText + disabledText)
+    this.logger.info(
+      `Using channels: ${this.app.channels
+        .list()
+        .map((x) => x.name)
+        .join(', ')}`
+    )
   }
 }

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -49,7 +49,7 @@ export class Logger {
     const time = moment().format(timeFormat)
 
     const timeText = clc.blackBright(time)
-    const titleText = clc.bold(this.colors[level](this.scope))
+    const titleText = clc.bold(this.colors[level](`[Messaging] ${this.scope}`))
 
     if (data) {
       // eslint-disable-next-line no-console

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -1,5 +1,6 @@
 import clc from 'cli-color'
 import moment from 'moment'
+import yn from 'yn'
 
 export enum LoggerLevel {
   Debug = 10,
@@ -49,7 +50,7 @@ export class Logger {
     const time = moment().format(timeFormat)
 
     const timeText = clc.blackBright(time)
-    const titleText = clc.bold(this.colors[level](`[Messaging] ${this.scope}`))
+    const titleText = clc.bold(this.colors[level](yn(process.env.SPINNED) ? `[Messaging] ${this.scope}` : this.scope))
 
     if (data) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Closes MES-48

I've made some minor changes to log files just so they fit better with the surrounding logs.

Since we have nlu, studio and messaging, we need to prepend log messages to indicate which process printed that log. The port is "useless" for the end user so i've grayed it, and we don'T need to print the external url since the server already prints it

![image](https://user-images.githubusercontent.com/42552874/125537144-324f060e-042c-485c-8f45-7bbeedc63357.png)
