### PR TITLE
feat(vonage): add support for voice audio reception

### DIFF
--- a/src/channels/vonage/conduit.ts
+++ b/src/channels/vonage/conduit.ts
@@ -42,11 +42,29 @@ export class VonageConduit extends ConduitInstance<VonageConfig, VonageContext> 
     const identity = payload.to.number
     const sender = payload.from.number
 
-    const index = Number(payload.message.content.text)
-    const text = this.handleIndexResponse(index, identity, sender) || payload.message.content.text
+    const messageContent = payload.message.content
+
+    let content = {}
+    switch (messageContent.type) {
+      case 'text':
+        const index = Number(messageContent.text)
+        const text = this.handleIndexResponse(index, identity, sender) || messageContent.text
+        content = { type: 'text', text }
+        break
+      case 'audio':
+        // We have to take for granted that all messages of type audio are voice messages
+        // since Vonage does not differentiate the two.
+        content = {
+          type: 'voice',
+          audio: messageContent.audio!.url
+        }
+        break
+      default:
+        break
+    }
 
     return {
-      content: { type: 'text', text },
+      content,
       identity,
       sender
     }


### PR DESCRIPTION
This PR adds support for voice audio reception with Vonage making sure that google-speech still works with this module.

Related to: https://github.com/botpress/studio/pull/33, https://github.com/botpress/botpress/pull/5197 and https://github.com/botpress/botpress/pull/5198

Closes MES-62