### PR TITLE
fix(base): handle exceptions when rendering and sending messages

### DIFF
--- a/src/channels/base/conduit.ts
+++ b/src/channels/base/conduit.ts
@@ -51,7 +51,7 @@ export abstract class ConduitInstance<TConfig, TContext extends ChannelContext<a
         client: undefined,
         handlers: 0,
         payload: _.cloneDeep(payload),
-        // TODO: temporary shorcut so that it works when botpress spins the messaging server. To be ajdusted when messaging is on cloud
+        // TODO: temporary shortcut so that it works when botpress spins the messaging server. To be adjusted when messaging is on cloud
         botUrl: process.env.BOT_URL!,
         logger: this.logger,
         ...endpoint
@@ -61,14 +61,23 @@ export abstract class ConduitInstance<TConfig, TContext extends ChannelContext<a
 
     for (const renderer of this.renderers) {
       if (renderer.handles(context)) {
-        renderer.render(context)
-        context.handlers++
+        try {
+          renderer.render(context)
+        } catch (err) {
+          this.logger.error('An error occurred when rendering a message', err)
+        } finally {
+          context.handlers++
+        }
       }
     }
 
     for (const sender of this.senders) {
       if (sender.handles(context)) {
-        await sender.send(context)
+        try {
+          await sender.send(context)
+        } catch (err) {
+          this.logger.error('An error occurred when sending a message', err)
+        }
       }
     }
   }

--- a/src/channels/slack/conduit.ts
+++ b/src/channels/slack/conduit.ts
@@ -119,7 +119,7 @@ export class SlackConduit extends ConduitInstance<SlackConfig, SlackContext> {
       }
     })
 
-    // com.on('error', (err) => this.bp.logger.attachError(err).error('An error occurred'))
+    com.on('error', (err) => this.logger.error('An error occurred', err))
   }
 
   public async extractEndpoint(payload: { ctx: any; content: any }): Promise<EndpointContent> {


### PR DESCRIPTION
This PR adds exception handling when rendering and sending messages on the base channel. And adds error handling with Slack's Event Adapter.

Fixes #26