### PR TITLE
feat(messenger): improved error handling and logging

### DIFF
--- a/src/channels/base/channel.ts
+++ b/src/channels/base/channel.ts
@@ -39,8 +39,7 @@ export abstract class Channel<TConduit extends ConduitInstance<any, any>> {
           throw new Error(`Unknown provider '${providerName}'. Make sure your webhook is properly configured`)
         }
 
-        const providerId = provider.id
-        const conduit = await this.app.conduits.getByProviderAndChannel(providerId, this.id)
+        const conduit = await this.app.conduits.getByProviderAndChannel(provider.id, this.id)
         if (!conduit) {
           throw new Error(
             `Cannot find a matching conduit for provider '${providerName}'. Make sure your channel is enabled and properly synced`

--- a/src/channels/base/channel.ts
+++ b/src/channels/base/channel.ts
@@ -37,12 +37,18 @@ export abstract class Channel<TConduit extends ConduitInstance<any, any>> {
         const provider = await this.app.providers.getByName(providerName)
         if (!provider) {
           throw new Error(`Unknown provider '${providerName}'. Make sure your webhook is properly configured`)
-        } else {
-          const providerId = provider.id
-          const conduit = (await this.app.conduits.getByProviderAndChannel(providerId, this.id))!
-          res.locals.conduit = await this.app.instances.get(conduit.id)
-          next()
         }
+
+        const providerId = provider.id
+        const conduit = await this.app.conduits.getByProviderAndChannel(providerId, this.id)
+        if (!conduit) {
+          throw new Error(
+            `Cannot find a matching conduit for provider '${providerName}'. Make sure your channel is enabled and properly synced`
+          )
+        }
+
+        res.locals.conduit = await this.app.instances.get(conduit.id)
+        next()
       }),
       this.router
     )

--- a/src/channels/base/conduit.ts
+++ b/src/channels/base/conduit.ts
@@ -64,7 +64,7 @@ export abstract class ConduitInstance<TConfig, TContext extends ChannelContext<a
         try {
           renderer.render(context)
         } catch (err) {
-          this.logger.error('An error occurred when rendering a message', err)
+          this.logger.error('An error occurred when rendering a message', (err as Error).message)
         } finally {
           context.handlers++
         }

--- a/src/channels/base/conduit.ts
+++ b/src/channels/base/conduit.ts
@@ -76,7 +76,7 @@ export abstract class ConduitInstance<TConfig, TContext extends ChannelContext<a
         try {
           await sender.send(context)
         } catch (err) {
-          this.logger.error('An error occurred when sending a message', err)
+          this.logger.error('An error occurred when sending a message:', (err as Error).message)
         }
       }
     }


### PR DESCRIPTION
This PR adds:

 - Handles the case where the provider exists by has no corresponding conduit (e.g. channel is disabled,  and not synced)
 - Only display the error message when a sender throw an error (since the error stack may contain Axios' response with sensitive information)
 -  Added typings and better logging on the `auth` function that handles payload validation