### PR TITLE
feat(smooch): add error handling during webhook setup

### DIFF
--- a/src/channels/smooch/conduit.ts
+++ b/src/channels/smooch/conduit.ts
@@ -30,12 +30,17 @@ export class SmoochConduit extends ConduitInstance<SmoochConfig, SmoochContext> 
   private async setupWebhook() {
     const target = await this.getRoute()
 
-    // Note: creating a webhook with the same url will not create a new webhook but return the already existing one
-    const { webhook }: { webhook: SmoochWebhook } = await this.smooch.webhooks.create({
-      target,
-      triggers: ['message:appUser']
-    })
-    this.secret = webhook.secret
+    try {
+      // Note: creating a webhook with the same url will not create a new webhook but return the already existing one
+      const { webhook }: { webhook: SmoochWebhook } = await this.smooch.webhooks.create({
+        target,
+        triggers: ['message:appUser']
+      })
+
+      this.secret = webhook.secret
+    } catch (err) {
+      this.logger.error('An error occurred when creating the webhook.', (err as Error).message)
+    }
   }
 
   protected setupRenderers() {


### PR DESCRIPTION
This PR adds error handling during the webhook setup. Otherwise, it would crash Messaging if the call fails!