### PR TITLE
feat(client): implement http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 bin/
 *.log
+.tsbuildinfo

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@botpress/messaging-client",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "AGPL-3.0",
+  "scripts": {
+    "build": "yarn --silent && tsc --build",
+    "watch": "yarn --silent && tsc --build --watch",
+    "prepublishOnly": "yarn --silent && tsc --build"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {},
+  "dependencies": {
+    "axios": "^0.21.1"
+  }
+}

--- a/packages/client/src/base.ts
+++ b/packages/client/src/base.ts
@@ -1,0 +1,5 @@
+import { AxiosInstance } from 'axios'
+
+export abstract class BaseClient {
+  constructor(protected http: AxiosInstance) {}
+}

--- a/packages/client/src/chat.ts
+++ b/packages/client/src/chat.ts
@@ -1,0 +1,8 @@
+import { BaseClient } from './base'
+import { Message } from './messages'
+
+export class ChatClient extends BaseClient {
+  async reply(conversationId: string, channel: string, payload: any): Promise<Message> {
+    return (await this.http.post('/chat/reply', { conversationId, channel, payload })).data
+  }
+}

--- a/packages/client/src/conversations.ts
+++ b/packages/client/src/conversations.ts
@@ -1,0 +1,31 @@
+import { BaseClient } from './base'
+import { Message } from './messages'
+
+export class ConversationClient extends BaseClient {
+  async create(userId: string): Promise<Conversation> {
+    return (await this.http.post('/conversations', { userId })).data
+  }
+
+  async get(id: string): Promise<Conversation> {
+    return (await this.http.get(`/conversations/${id}`)).data
+  }
+
+  async list(userId: string, limit: number): Promise<ConversationWithLastMessage[]> {
+    return (await this.http.get('/conversations', { params: { userId, limit } })).data
+  }
+
+  async getRecent(userId: string): Promise<Conversation> {
+    return (await this.http.get(`/conversations/${userId}/recent`)).data
+  }
+}
+
+export interface Conversation {
+  id: string
+  clientId: string
+  userId: string
+  createdOn: Date
+}
+
+export interface ConversationWithLastMessage extends Conversation {
+  lastMessage?: Message
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,0 +1,7 @@
+export * from './base'
+export * from './chat'
+export * from './conversations'
+export * from './messages'
+export * from './messaging'
+export * from './sync'
+export * from './users'

--- a/packages/client/src/messages.ts
+++ b/packages/client/src/messages.ts
@@ -1,0 +1,27 @@
+import { BaseClient } from './base'
+
+export class MessageClient extends BaseClient {
+  async create(conversationId: string, authorId: string | undefined, payload: any): Promise<Message> {
+    return (await this.http.post('/messages', { conversationId, authorId, payload })).data
+  }
+
+  async get(id: string): Promise<Message> {
+    return (await this.http.get(`/messages/${id}`)).data
+  }
+
+  async list(conversationId: string, limit: number): Promise<Message[]> {
+    return (await this.http.get('/messages', { params: { conversationId, limit } })).data
+  }
+
+  async delete(filters: { id?: string; conversationId?: string }): Promise<number> {
+    return (await this.http.delete('/messages', { params: filters })).data
+  }
+}
+
+export interface Message {
+  id: string
+  conversationId: string
+  authorId: string | undefined
+  sentOn: Date
+  payload: any
+}

--- a/packages/client/src/messaging.ts
+++ b/packages/client/src/messaging.ts
@@ -1,0 +1,45 @@
+import axios, { AxiosInstance } from 'axios'
+import { ChatClient } from './chat'
+import { ConversationClient } from './conversations'
+import { MessageClient } from './messages'
+import { SyncClient } from './sync'
+import { UserClient } from './users'
+
+export class MessagingClient {
+  http: AxiosInstance
+  authHttp: AxiosInstance
+  syncs: SyncClient
+  chat: ChatClient
+  users: UserClient
+  conversations: ConversationClient
+  messages: MessageClient
+
+  constructor(options: MessagingOptions) {
+    const { url, password, auth } = options
+
+    this.http = axios.create({ baseURL: `${url}/api`, headers: { password } })
+    this.authHttp = axios.create({
+      baseURL: `${url}/api`,
+      headers: { password },
+      auth: { username: auth?.clientId!, password: auth?.clientToken! }
+    })
+
+    this.syncs = new SyncClient(this.http)
+    this.chat = new ChatClient(this.authHttp)
+    this.users = new UserClient(this.authHttp)
+    this.conversations = new ConversationClient(this.authHttp)
+    this.messages = new MessageClient(this.authHttp)
+  }
+}
+
+export interface MessagingOptions {
+  /** Base url of the messaging server */
+  url: string
+  /** Internal password of the messaging server. Optional */
+  password?: string
+  /** Client authentification to access client owned ressources. Optional */
+  auth?: {
+    clientId: string
+    clientToken: string
+  }
+}

--- a/packages/client/src/sync.ts
+++ b/packages/client/src/sync.ts
@@ -1,0 +1,36 @@
+import { BaseClient } from './base'
+
+export class SyncClient extends BaseClient {
+  async sync(config: SyncRequest): Promise<SyncResult> {
+    return (await this.http.post('/sync', config)).data
+  }
+}
+
+// TODO: these typings are copy pasted. Maybe a "common" package would be good for this?
+export interface SyncRequest {
+  channels?: SyncChannels
+  webhooks?: SyncWebhook[]
+  id?: string
+  token?: string
+  name?: string
+}
+
+export interface SyncResult {
+  id: string
+  token: string
+  webhooks: SyncWebhook[]
+}
+
+export interface SyncSandboxRequest {
+  name: string
+  channels?: SyncChannels
+}
+
+export interface SyncChannels {
+  [channel: string]: any
+}
+
+export interface SyncWebhook {
+  url: string
+  token?: string
+}

--- a/packages/client/src/users.ts
+++ b/packages/client/src/users.ts
@@ -1,0 +1,12 @@
+import { BaseClient } from './base'
+
+export class UserClient extends BaseClient {
+  async create(): Promise<User> {
+    return (await this.http.post('/users')).data
+  }
+}
+
+export interface User {
+  id: string
+  clientId: string
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // Manage references here
+  "references": [],
+
+  // Defaults (don't change this)
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": ".tsbuildinfo",
+
+    // Specific settings for npm package
+    "target": "es6",
+    "declaration": true,
+    "sourceMap": false
+  },
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,9 @@
   "references": [
     {
       "path": "./packages/server"
+    },
+    {
+      "path": "./packages/client"
     }
   ],
   "files": [],


### PR DESCRIPTION
This client is meant to be used has an npm package by the old repo (and any other services) to communicate with messaging. It provides typings for everything

I think a new package should be made to hold typings that are shared between the `client` and the `server` package. It could be called `shared` or `common` and would avoid copy pasting typings from the server to the client (like I did here for example).

PR in main repo https://github.com/botpress/botpress/pull/5209

Closes MES-60