### PR TITLE
chore(github): bump github actions nodejs version to 12.18.3

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.13.0'
+          node-version: '12.18.3'
       - name: Install Dependencies
         run: |
           yarn
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.13.0'
+          node-version: '12.18.3'
       - name: Install Dependencies
         run: |
           yarn


### PR DESCRIPTION
This PR fixes the GitHub actions check that was failing because one of our dependencies required NodeJS >= 12.18.3. See: https://github.com/botpress/messaging/pull/51/checks?check_run_id=3148014125