### PR TITLE
fix(channels): fix request proxying requiring to use router.use

### DIFF
--- a/packages/server/src/channels/messenger/channel.ts
+++ b/packages/server/src/channels/messenger/channel.ts
@@ -29,15 +29,17 @@ export class MessengerChannel extends Channel<MessengerConduit> {
   async setupRoutes() {
     this.router.use(express.json({ verify: this.auth.bind(this) }))
 
-    this.router.use(
+    this.router.get(
       '/',
       this.asyncMiddleware(async (req, res) => {
-        // For some reason proxy doesn't work with .post and .get so we need to check req.method manually
-        if (req.method === 'GET') {
-          await this.handleWebhookVerification(req, res)
-        } else if (req.method === 'POST') {
-          await this.handleMessageRequest(req, res)
-        }
+        await this.handleWebhookVerification(req, res)
+      })
+    )
+
+    this.router.post(
+      '/',
+      this.asyncMiddleware(async (req, res) => {
+        await this.handleMessageRequest(req, res)
       })
     )
 

--- a/packages/server/src/channels/messenger/client.ts
+++ b/packages/server/src/channels/messenger/client.ts
@@ -21,7 +21,7 @@ export class MessengerClient {
         }
       })
     } catch (e) {
-      this.logger.error('Error occured trying to setup "getStarted" message.', e.message)
+      this.logger.error('Error occurred trying to setup "getStarted" message.', e.message)
     }
   }
 
@@ -41,7 +41,7 @@ export class MessengerClient {
         ]
       })
     } catch (e) {
-      this.logger.error('Error occured trying to setup greeting.', e.message)
+      this.logger.error('Error occurred trying to setup greeting.', e.message)
     }
   }
 
@@ -54,7 +54,7 @@ export class MessengerClient {
     try {
       await this.sendProfile({ persistent_menu: this.config.persistentMenu })
     } catch (e) {
-      this.logger.error('Error occured trying to setup persistent menu.', e.message)
+      this.logger.error('Error occurred trying to setup persistent menu.', e.message)
     }
   }
 

--- a/packages/server/src/channels/slack/channel.ts
+++ b/packages/server/src/channels/slack/channel.ts
@@ -20,7 +20,7 @@ export class SlackChannel extends Channel<SlackConduit> {
   }
 
   async setupRoutes() {
-    this.router.use(
+    this.router.post(
       '/interactive',
       this.asyncMiddleware(async (req, res) => {
         const conduit = res.locals.conduit as SlackConduit
@@ -29,7 +29,7 @@ export class SlackChannel extends Channel<SlackConduit> {
     )
     this.printWebhook('interactive')
 
-    this.router.use(
+    this.router.post(
       '/events',
       this.asyncMiddleware(async (req, res) => {
         const conduit = res.locals.conduit as SlackConduit

--- a/packages/server/src/channels/slack/conduit.ts
+++ b/packages/server/src/channels/slack/conduit.ts
@@ -62,7 +62,7 @@ export class SlackConduit extends ConduitInstance<SlackConfig, SlackContext> {
         content: { type: 'quick_reply', text: action?.text?.text, payload: action?.value }
       })
     } catch (e) {
-      this.logger.error('Error occured while processing a "button" interactive action.', e)
+      this.logger.error('Error occurred while processing a "button" interactive action.', e)
     }
   }
 
@@ -78,7 +78,7 @@ export class SlackConduit extends ConduitInstance<SlackConfig, SlackContext> {
         content: { type: 'quick_reply', text: label, payload: action?.value }
       })
     } catch (e) {
-      this.logger.error('Error occured while processing a "option_selected" interactive action.', e)
+      this.logger.error('Error occurred while processing a "option_selected" interactive action.', e)
     }
   }
 
@@ -96,7 +96,7 @@ export class SlackConduit extends ConduitInstance<SlackConfig, SlackContext> {
         }
       })
     } catch (e) {
-      this.logger.error('Error occured while processing a slack message.', e)
+      this.logger.error('Error occurred while processing a slack message.', e)
     }
   }
 

--- a/packages/server/src/channels/smooch/channel.ts
+++ b/packages/server/src/channels/smooch/channel.ts
@@ -28,7 +28,7 @@ export class SmoochChannel extends Channel<SmoochConduit> {
   async setupRoutes() {
     this.router.use(express.json())
 
-    this.router.use(
+    this.router.post(
       '/',
       this.asyncMiddleware(async (req, res) => {
         const conduit = res.locals.conduit as SmoochConduit
@@ -40,7 +40,7 @@ export class SmoochChannel extends Channel<SmoochConduit> {
           }
           res.sendStatus(200)
         } else {
-          res.status(401).send('Auth token invalid')
+          res.sendStatus(401)
         }
       })
     )

--- a/packages/server/src/channels/teams/channel.ts
+++ b/packages/server/src/channels/teams/channel.ts
@@ -20,7 +20,7 @@ export class TeamsChannel extends Channel<TeamsConduit> {
   }
 
   async setupRoutes() {
-    this.router.use(
+    this.router.post(
       '/',
       this.asyncMiddleware(async (req, res) => {
         const conduit = res.locals.conduit as TeamsConduit
@@ -33,7 +33,7 @@ export class TeamsChannel extends Channel<TeamsConduit> {
               await this.app.instances.receive(conduit.conduitId, turnContext)
             }
           } catch (e) {
-            conduit.logger.error('Error occured processing teams activity.', e)
+            conduit.logger.error('Error occurred processing teams activity.', e)
           }
         })
       })

--- a/packages/server/src/channels/telegram/channel.ts
+++ b/packages/server/src/channels/telegram/channel.ts
@@ -25,7 +25,7 @@ export class TelegramChannel extends Channel<TelegramConduit> {
   }
 
   async setupRoutes() {
-    this.router.use(
+    this.router.post(
       '/:token',
       this.asyncMiddleware(async (req, res) => {
         // This is done to make forwarding work

--- a/packages/server/src/channels/twilio/channel.ts
+++ b/packages/server/src/channels/twilio/channel.ts
@@ -24,9 +24,10 @@ export class TwilioChannel extends Channel<TwilioConduit> {
   async setupRoutes() {
     this.router.use(express.urlencoded({ extended: true }))
 
-    this.router.use(
+    this.router.post(
       '/',
       this.asyncMiddleware(async (req, res) => {
+        console.dir(req)
         const conduit = res.locals.conduit as TwilioConduit
         const signature = req.headers['x-twilio-signature'] as string
         // TODO: Remove this once we deprecate the old webhooks
@@ -40,7 +41,7 @@ export class TwilioChannel extends Channel<TwilioConduit> {
         } else {
           this.logger.error('Request validation failed. Make sure that your authToken is valid.')
 
-          res.status(401).send('Auth token invalid')
+          res.sendStatus(401)
         }
       })
     )

--- a/packages/server/src/channels/twilio/channel.ts
+++ b/packages/server/src/channels/twilio/channel.ts
@@ -27,7 +27,6 @@ export class TwilioChannel extends Channel<TwilioConduit> {
     this.router.post(
       '/',
       this.asyncMiddleware(async (req, res) => {
-        console.dir(req)
         const conduit = res.locals.conduit as TwilioConduit
         const signature = req.headers['x-twilio-signature'] as string
         // TODO: Remove this once we deprecate the old webhooks

--- a/packages/server/src/channels/vonage/channel.ts
+++ b/packages/server/src/channels/vonage/channel.ts
@@ -25,7 +25,7 @@ export class VonageChannel extends Channel<VonageConduit> {
   async setupRoutes() {
     this.router.use(express.json())
 
-    this.router.use(
+    this.router.post(
       '/inbound',
       this.asyncMiddleware(async (req, res) => {
         const conduit = res.locals.conduit as VonageConduit
@@ -37,7 +37,7 @@ export class VonageChannel extends Channel<VonageConduit> {
         res.sendStatus(200)
       })
     )
-    this.router.use(
+    this.router.post(
       '/status',
       this.asyncMiddleware(async (req, res) => {
         res.sendStatus(200)


### PR DESCRIPTION
This PR fixes an issue where all routes In messaging add to be defined using router.use because of a misconfiguration of the middleware proxy in the main repo (see: https://github.com/botpress/botpress/pull/5112/commits/035a123b507a3e77369f5ea3631bde2eca5afc95)

Closes MES-41