### PR TITLE
fix(channels): loosen joi schema validation by discarding unknown properties

### DIFF
--- a/packages/server/src/channels/discord/config.ts
+++ b/packages/server/src/channels/discord/config.ts
@@ -6,4 +6,4 @@ export interface DiscordConfig {
 
 export const DiscordConfigSchema = Joi.object({
   token: Joi.string().required()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/channels/messenger/config.ts
+++ b/packages/server/src/channels/messenger/config.ts
@@ -19,4 +19,4 @@ export const MessengerConfigSchema = Joi.object({
   greeting: Joi.string().optional(),
   getStarted: Joi.string().optional(),
   persistentMenu: Joi.array().optional()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/channels/slack/config.ts
+++ b/packages/server/src/channels/slack/config.ts
@@ -10,4 +10,4 @@ export const SlackConfigSchema = Joi.object({
   botToken: Joi.string().required(),
   signingSecret: Joi.string().required(),
   useRTM: Joi.boolean().optional()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/channels/smooch/config.ts
+++ b/packages/server/src/channels/smooch/config.ts
@@ -10,4 +10,4 @@ export const SmoochConfigSchema = Joi.object({
   keyId: Joi.string().required(),
   secret: Joi.string().required(),
   forwardRawPayloads: Joi.array().items(Joi.string()).optional()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/channels/teams/config.ts
+++ b/packages/server/src/channels/teams/config.ts
@@ -14,4 +14,4 @@ export const TeamsConfigSchema = Joi.object({
   appPassword: Joi.string().required(),
   tenantId: Joi.string().optional(),
   proactiveMessages: Joi.object().optional()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/channels/telegram/config.ts
+++ b/packages/server/src/channels/telegram/config.ts
@@ -6,4 +6,4 @@ export interface TelegramConfig {
 
 export const TelegramConfigSchema = Joi.object({
   botToken: Joi.string().required()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/channels/twilio/config.ts
+++ b/packages/server/src/channels/twilio/config.ts
@@ -8,4 +8,4 @@ export interface TwilioConfig {
 export const TwilioConfigSchema = Joi.object({
   accountSID: Joi.string().required(),
   authToken: Joi.string().required()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/channels/vonage/config.ts
+++ b/packages/server/src/channels/vonage/config.ts
@@ -16,4 +16,4 @@ export const VonageConfigSchema = Joi.object({
   applicationId: Joi.string().required(),
   privateKey: Joi.string().required(),
   useTestingApi: Joi.boolean().optional()
-})
+}).options({ stripUnknown: true })

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -95,7 +95,7 @@ export class InstanceService extends Service {
     try {
       await instance.initialize()
     } catch (e) {
-      instance.logger.error('Error trying to initialize conduit.', e)
+      instance.logger.error('Error trying to initialize conduit.', (e as Error).message)
       this.cache.del(conduitId)
       return
     }

--- a/packages/server/src/sync/api.ts
+++ b/packages/server/src/sync/api.ts
@@ -38,12 +38,12 @@ export class SyncApi extends BaseApi {
         }
         const bodyWithoutEnabled = { ...(req.body || {}), channels: channelsWithoutEnabled }
 
-        const { error } = requestSchema.validate(bodyWithoutEnabled)
+        const { error, value } = requestSchema.validate(bodyWithoutEnabled)
         if (error) {
           return res.status(400).send(error.message)
         }
 
-        const sync = req.body as SyncRequest
+        const sync = value as SyncRequest
 
         // We forbid sync requests that act on existing clients (valid clientId) but don't provide the correct token
         // A sync request will accept a incorrect client id (we assume the client was deleted a provide a new client id in response)

--- a/packages/server/src/sync/service.ts
+++ b/packages/server/src/sync/service.ts
@@ -83,7 +83,8 @@ export class SyncService extends Service {
     const oldConduits = [...(await this.conduits.listByProvider(providerId))]
 
     for (const [channel, config] of Object.entries(conduits)) {
-      if (!config.enabled) {
+      // A conduit is enabled by default (don't need to set enabled: true)
+      if (config.enabled !== undefined && !config.enabled) {
         continue
       }
       const configWithoutEnabled = _.omit(config, ['enabled'])


### PR DESCRIPTION
This PR loosens Joi schema validation by discarding unknown properties instead of throwing an error.