### PR TITLE
fix(sync): assure botId always returns same clientId

### DIFF
--- a/packages/server/src/clients/service.ts
+++ b/packages/server/src/clients/service.ts
@@ -120,8 +120,22 @@ export class ClientService extends Service {
 
     this.cacheByProvider.del(oldClient.providerId, true)
     this.cacheById.del(id, true)
+    this.cacheTokens.del(id, true)
 
     await this.query().where({ id }).update({ providerId })
+    await this.emitter.emit(ClientEvents.Updated, { clientId: id, oldClient })
+  }
+
+  async updateToken(id: uuid, token: string) {
+    const oldClient = (await this.getById(id))!
+
+    this.cacheByProvider.del(oldClient.providerId, true)
+    this.cacheById.del(id, true)
+    this.cacheTokens.del(id, true)
+
+    await this.query()
+      .where({ id })
+      .update({ token: await this.cryptoService.hash(token) })
     await this.emitter.emit(ClientEvents.Updated, { clientId: id, oldClient })
   }
 

--- a/packages/server/src/sync/service.ts
+++ b/packages/server/src/sync/service.ts
@@ -124,6 +124,19 @@ export class SyncService extends Service {
       client = await this.clients.getById(clientId)
     }
 
+    // For when messaging is spinned. Assures that a certain botId always gets back the same clientId when calling messaging
+    if (!client && forceProviderName && !forceClientId) {
+      const exisingProvider = await this.providers.getByName(forceProviderName)
+      if (exisingProvider) {
+        const existingClient = await this.clients.getByProviderId(exisingProvider.id)
+        if (existingClient) {
+          token = forceToken || (await this.clients.generateToken())
+          await this.clients.updateToken(existingClient.id, token)
+          client = await this.clients.getById(existingClient.id)
+        }
+      }
+    }
+
     if (!client) {
       const clientId = forceClientId || uuidv4()
       provider = await this.providers.create(clientId, false)


### PR DESCRIPTION
This fixes a problem where you could delete a bot in botpress and create a new bot with the same exact id. For most botpress services this bot will be considered to be the same bot because it has the same id. For messaging however the sync call would return a entirely new clientId and would treat it like a completely different client.

This PR changes this behavior so that you get back the same clientId (if possible) so that this new bot is considered to be the same client. We generate a new token for the bot to use with the old client id.

This will solve a problem in our migration. For example right now we create clientIds and tokens for bots that do not exist when running the migration. If someone were to reimport those missing bots, they couldn't access the old conversations of that bot because the clientId would be a completely new clientId. So this PR fixes that

Closes MES-85