### PR TITLE
fix(health): fix crash when conduit is deleted

### DIFF
--- a/packages/server/src/health/table.ts
+++ b/packages/server/src/health/table.ts
@@ -8,7 +8,7 @@ export class HealthTable extends Table {
 
   create(table: Knex.CreateTableBuilder) {
     table.uuid('id').primary()
-    table.uuid('conduitId').references('id').inTable('msg_conduits').notNullable()
+    table.uuid('conduitId').references('id').inTable('msg_conduits').notNullable().onDelete('cascade')
     table.timestamp('time').notNullable()
     table.string('type').notNullable()
     table.jsonb('data').nullable()


### PR DESCRIPTION
Added a onCascade(delete) to the health events table so foreing key constraints don't fail when a conduit is deleted.

Closes MES-96