### PR TITLE
fix(webhook): removed spinned url env var

### DIFF
--- a/packages/server/src/global.ts
+++ b/packages/server/src/global.ts
@@ -15,7 +15,6 @@ export interface MessagingEnv {
   SKIP_LOAD_CONFIG?: string
   SKIP_LOAD_ENV?: string
   SPINNED?: string
-  SPINNED_URL?: string
   NO_LAZY_LOADING?: string
   BATCHING_ENABLED?: string
 }

--- a/packages/server/src/health/service.ts
+++ b/packages/server/src/health/service.ts
@@ -66,15 +66,10 @@ export class HealthService extends Service {
         event: this.makeReadable(event)
       }
 
-      // TODO: this code to call webhook is copy pasted. It should be refactored somewhere else
-      if (yn(process.env.SPINNED)) {
-        await this.callWebhook(process.env.SPINNED_URL!, post)
-      } else {
-        const webhooks = await this.webhookService.list(client.id)
+      const webhooks = await this.webhookService.list(client.id)
 
-        for (const webhook of webhooks) {
-          await this.callWebhook(webhook.url, post, webhook.token)
-        }
+      for (const webhook of webhooks) {
+        await this.callWebhook(webhook.url, post, webhook.token)
       }
     }
 

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -216,14 +216,10 @@ export class InstanceService extends Service {
       instance.loggerIn.debug('Received message', post)
     }
 
-    if (yn(process.env.SPINNED)) {
-      await this.callWebhook(instance, process.env.SPINNED_URL!, post)
-    } else {
-      const webhooks = await this.webhookService.list(clientId)
+    const webhooks = await this.webhookService.list(clientId)
 
-      for (const webhook of webhooks) {
-        await this.callWebhook(instance, webhook.url, post, webhook.token)
-      }
+    for (const webhook of webhooks) {
+      await this.callWebhook(instance, webhook.url, post, webhook.token)
     }
   }
 


### PR DESCRIPTION
An instance of Botpress that starts messaging as a subprocess will also use webhooks from now on.