### PR TITLE
fix(auth): use custom headers instead of basic auth

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/packages/server/src/base/api.ts
+++ b/packages/server/src/base/api.ts
@@ -28,9 +28,8 @@ export abstract class ClientScopedApi extends BaseApi {
 
   async extractClient(req: ApiRequest, res: Response, next: NextFunction) {
     try {
-      const authorization = req.headers.authorization
-      const [_, auth] = authorization!.split(' ')
-      const [clientId, clientToken] = Buffer.from(auth, 'base64').toString('utf-8').split(':')
+      const clientId = req.headers['x-bp-messaging-client-id'] as string
+      const clientToken = req.headers['x-bp-messaging-client-token'] as string
 
       if (!validateUuid(clientId)) {
         return res.sendStatus(403)


### PR DESCRIPTION
This PR fixes an issue where multiple authentication mechanisms could conflict with our basic authentication. We will now need to provide a 'x-bp-messaging-client-*' headers to provide the clientId and clientToken.