### PR TITLE
fix(twilio): fix twilio webhooks validation

### DIFF
--- a/packages/server/src/channels/twilio/channel.ts
+++ b/packages/server/src/channels/twilio/channel.ts
@@ -52,7 +52,7 @@ export class TwilioChannel extends Channel<TwilioConduit> {
     const conduit = await this.app.conduits.get(instance.conduitId)
     const provider = await this.app.providers.getById(conduit!.providerId)
 
-    const oldUrl = `https://${req.headers.host}/api/v1/bots/${provider!.name}/mod/channel-twilio/webhook`
+    const oldUrl = `${req.headers['x-bp-host']}/api/v1/bots/${provider!.name}/mod/channel-twilio/webhook`
 
     return validateRequest(instance.config.authToken, signature, oldUrl, req.body)
   }


### PR DESCRIPTION
This PR fixes an issue where having an external URL with a port specified would not allow you to use the old webhooks with Twilio.

Related to: https://github.com/botpress/botpress/pull/5266

Closes https://github.com/botpress/messaging/issues/85