### PR TITLE
feat(distributed): implement locking

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
     "@types/lru-cache": "^5.1.0",
     "@types/ms": "^0.7.31",
     "@types/node": "^15.0.0",
+    "@types/redlock": "^4.0.2",
     "@types/uuid": "^8.3.0"
   },
   "dependencies": {
@@ -45,6 +46,7 @@
     "ms": "^2.1.3",
     "pg": "^8.6.0",
     "portfinder": "^1.0.28",
+    "redlock": "^4.2.0",
     "smooch-core": "^8.11.4",
     "sqlite3": "^5.0.2",
     "telegraf": "^3.27.1",

--- a/packages/server/src/distributed/base/subservice.ts
+++ b/packages/server/src/distributed/base/subservice.ts
@@ -1,6 +1,10 @@
+import { Lock } from '../types'
+
 export interface DistributedSubservice {
   setup(): Promise<void>
   destroy(): Promise<void>
   listen(channel: string, callback: (message: any) => Promise<void>): Promise<void>
   send(channel: string, message: any): Promise<void>
+  lock(ressource: string): Promise<Lock>
+  release(lock: Lock): Promise<void>
 }

--- a/packages/server/src/distributed/local/subservice.ts
+++ b/packages/server/src/distributed/local/subservice.ts
@@ -24,7 +24,7 @@ export class LocalSubservice implements DistributedSubservice {
       const attempt = () => {
         const lock = this.tryGetLock(ressource)
         if (lock) {
-          return resolve(lock)
+          resolve(lock)
         } else if (attemptCount < MAX_LOCK_ATTEMPT) {
           attemptCount++
           setTimeout(attempt, LOCK_ATTEMPT_INTERVAL + Math.random() * LOCK_ATTEMPT_INTERVAL_JITTER)

--- a/packages/server/src/distributed/local/subservice.ts
+++ b/packages/server/src/distributed/local/subservice.ts
@@ -1,7 +1,7 @@
 import { DistributedSubservice } from '../base/subservice'
 import { Lock } from '../types'
 
-const DEFAULT_LOCK_TTL = 20000
+const DEFAULT_LOCK_TTL = 2000
 const MAX_LOCK_ATTEMPT = 10
 const LOCK_ATTEMPT_INTERVAL = 200
 const LOCK_ATTEMPT_INTERVAL_JITTER = 100

--- a/packages/server/src/distributed/local/subservice.ts
+++ b/packages/server/src/distributed/local/subservice.ts
@@ -2,6 +2,8 @@ import { DistributedSubservice } from '../base/subservice'
 import { Lock } from '../types'
 
 export class LocalSubservice implements DistributedSubservice {
+  private locks: { [ressource: string]: boolean } = {}
+
   async setup() {}
 
   async destroy() {}
@@ -11,8 +13,15 @@ export class LocalSubservice implements DistributedSubservice {
   async send(channel: string, message: any) {}
 
   async lock(ressource: string): Promise<Lock> {
-    return { ressource }
+    if (!this.locks[ressource]) {
+      this.locks[ressource] = true
+      return { ressource }
+    } else {
+      throw new Error('Failed to acquire lock. Already in use.')
+    }
   }
 
-  async release(lock: Lock) {}
+  async release(lock: Lock) {
+    delete this.locks[lock.ressource]
+  }
 }

--- a/packages/server/src/distributed/local/subservice.ts
+++ b/packages/server/src/distributed/local/subservice.ts
@@ -1,4 +1,5 @@
 import { DistributedSubservice } from '../base/subservice'
+import { Lock } from '../types'
 
 export class LocalSubservice implements DistributedSubservice {
   async setup() {}
@@ -8,4 +9,10 @@ export class LocalSubservice implements DistributedSubservice {
   async listen(channel: string, callback: (message: any) => Promise<void>) {}
 
   async send(channel: string, message: any) {}
+
+  async lock(ressource: string): Promise<Lock> {
+    return { ressource }
+  }
+
+  async release(lock: Lock) {}
 }

--- a/packages/server/src/distributed/local/subservice.ts
+++ b/packages/server/src/distributed/local/subservice.ts
@@ -1,8 +1,13 @@
 import { DistributedSubservice } from '../base/subservice'
 import { Lock } from '../types'
 
+const DEFAULT_LOCK_TTL = 20000
+const MAX_LOCK_ATTEMPT = 10
+const LOCK_ATTEMPT_INTERVAL = 200
+const LOCK_ATTEMPT_INTERVAL_JITTER = 100
+
 export class LocalSubservice implements DistributedSubservice {
-  private locks: { [ressource: string]: boolean } = {}
+  private locks: { [ressource: string]: Date } = {}
 
   async setup() {}
 
@@ -13,15 +18,35 @@ export class LocalSubservice implements DistributedSubservice {
   async send(channel: string, message: any) {}
 
   async lock(ressource: string): Promise<Lock> {
-    if (!this.locks[ressource]) {
-      this.locks[ressource] = true
-      return { ressource }
-    } else {
-      throw new Error('Failed to acquire lock. Already in use.')
-    }
+    let attemptCount = 0
+
+    return new Promise<Lock>((resolve, reject) => {
+      const attempt = () => {
+        const lock = this.tryGetLock(ressource)
+        if (lock) {
+          return resolve(lock)
+        } else if (attemptCount < MAX_LOCK_ATTEMPT) {
+          attemptCount++
+          setTimeout(attempt, LOCK_ATTEMPT_INTERVAL + Math.random() * LOCK_ATTEMPT_INTERVAL_JITTER)
+        } else {
+          reject(new Error('Failed to acquire lock. Already in use'))
+        }
+      }
+
+      attempt()
+    })
   }
 
   async release(lock: Lock) {
     delete this.locks[lock.ressource]
+  }
+
+  private tryGetLock(ressource: string) {
+    if (!this.locks[ressource] || this.locks[ressource] < new Date()) {
+      this.locks[ressource] = new Date(new Date().getTime() + DEFAULT_LOCK_TTL)
+      return { ressource }
+    } else {
+      return undefined
+    }
   }
 }

--- a/packages/server/src/distributed/redis/subservice.ts
+++ b/packages/server/src/distributed/redis/subservice.ts
@@ -7,6 +7,8 @@ import { DistributedSubservice } from '../base/subservice'
 import { RedisConfig } from './config'
 import { PingPong } from './ping'
 
+const DEFAULT_LOCK_TTL = 2000
+
 export class RedisSubservice implements DistributedSubservice {
   private logger: Logger = new Logger('Redis')
   private nodeId!: number
@@ -122,7 +124,7 @@ export class RedisSubservice implements DistributedSubservice {
   }
 
   async lock(ressource: string) {
-    const ttl = 2000
+    const ttl = DEFAULT_LOCK_TTL
     const lock = {
       lock: await this.redlock.acquire(ressource, ttl),
       ressource,

--- a/packages/server/src/distributed/redis/subservice.ts
+++ b/packages/server/src/distributed/redis/subservice.ts
@@ -1,6 +1,7 @@
 import clc from 'cli-color'
 import redis, { ClusterOptions, Redis, RedisOptions } from 'ioredis'
 import _ from 'lodash'
+import Redlock from 'redlock'
 import { Logger } from '../../logger/types'
 import { DistributedSubservice } from '../base/subservice'
 import { RedisConfig } from './config'
@@ -11,6 +12,8 @@ export class RedisSubservice implements DistributedSubservice {
   private nodeId!: number
   private pub!: Redis
   private sub!: Redis
+  private redlock!: Redlock
+  private locks: { [ressource: string]: RedisLock } = {}
   private callbacks: { [channel: string]: (message: any) => Promise<void> } = {}
   private pings!: PingPong
   private scope!: string
@@ -24,6 +27,7 @@ export class RedisSubservice implements DistributedSubservice {
     this.scope = process.env.REDIS_SCOPE || this.config.scope
     this.pub = this.setupClient()
     this.sub = this.setupClient()
+    this.redlock = new Redlock([this.pub])
 
     this.sub.on('message', (channel, message) => {
       const callback = this.callbacks[channel]
@@ -84,8 +88,24 @@ export class RedisSubservice implements DistributedSubservice {
   }
 
   async destroy() {
-    await this.pub.quit()
-    await this.sub.quit()
+    const now = new Date()
+
+    for (const lock of Object.values(this.locks)) {
+      if (lock.expiry > now) {
+        try {
+          await this.release(lock)
+        } catch {
+          this.logger.error('Failed to release lock', _.omit(lock, 'lock'))
+        }
+      }
+    }
+
+    try {
+      await this.pub.quit()
+      await this.sub.quit()
+    } catch {
+      this.logger.error('Failed to destroy connections')
+    }
   }
 
   async listen(channel: string, callback: (message: any) => Promise<void>) {
@@ -101,7 +121,29 @@ export class RedisSubservice implements DistributedSubservice {
     await this.pub.publish(scopedChannel, JSON.stringify({ nodeId: this.nodeId, ...message }))
   }
 
+  async lock(ressource: string) {
+    const ttl = 2000
+    const lock = {
+      lock: await this.redlock.acquire(ressource, ttl),
+      ressource,
+      expiry: new Date(new Date().getTime() + ttl)
+    }
+    this.locks[ressource] = lock
+    return lock
+  }
+
+  async release(lock: RedisLock) {
+    await this.redlock.release(lock.lock)
+    delete this.locks[lock.ressource]
+  }
+
   private makeScopedChannel(key: string): string {
     return this.scope ? `${this.scope}/${key}` : key
   }
+}
+
+interface RedisLock {
+  ressource: string
+  expiry: Date
+  lock: Redlock.Lock
 }

--- a/packages/server/src/distributed/service.ts
+++ b/packages/server/src/distributed/service.ts
@@ -5,6 +5,7 @@ import { DistributedSubservice } from './base/subservice'
 import { LocalSubservice } from './local/subservice'
 import { RedisConfig } from './redis/config'
 import { RedisSubservice } from './redis/subservice'
+import { Lock } from './types'
 
 export class DistributedService extends Service {
   private subservice!: DistributedSubservice
@@ -35,5 +36,19 @@ export class DistributedService extends Service {
 
   async send(channel: string, message: any) {
     return this.subservice.send(channel, message)
+  }
+
+  async lock(ressource: string): Promise<Lock> {
+    return this.subservice.lock(ressource)
+  }
+
+  async release(lock: Lock) {
+    await this.subservice.release(lock)
+  }
+
+  async using(ressource: string, callback: () => Promise<void>) {
+    const lock = await this.lock(ressource)
+    await callback()
+    await this.release(lock)
   }
 }

--- a/packages/server/src/distributed/service.ts
+++ b/packages/server/src/distributed/service.ts
@@ -48,7 +48,12 @@ export class DistributedService extends Service {
 
   async using(ressource: string, callback: () => Promise<void>) {
     const lock = await this.lock(ressource)
-    await callback()
-    await this.release(lock)
+    try {
+      await callback()
+    } catch (e) {
+      throw e
+    } finally {
+      await this.release(lock)
+    }
   }
 }

--- a/packages/server/src/distributed/service.ts
+++ b/packages/server/src/distributed/service.ts
@@ -38,14 +38,6 @@ export class DistributedService extends Service {
     return this.subservice.send(channel, message)
   }
 
-  async lock(ressource: string): Promise<Lock> {
-    return this.subservice.lock(ressource)
-  }
-
-  async release(lock: Lock) {
-    await this.subservice.release(lock)
-  }
-
   async using(ressource: string, callback: () => Promise<void>) {
     const lock = await this.lock(ressource)
     try {
@@ -55,5 +47,13 @@ export class DistributedService extends Service {
     } finally {
       await this.release(lock)
     }
+  }
+
+  private async lock(ressource: string): Promise<Lock> {
+    return this.subservice.lock(ressource)
+  }
+
+  private async release(lock: Lock) {
+    await this.subservice.release(lock)
   }
 }

--- a/packages/server/src/distributed/types.ts
+++ b/packages/server/src/distributed/types.ts
@@ -1,0 +1,3 @@
+export interface Lock {
+  ressource: string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,6 +1024,11 @@
   resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.2.tgz#e3530eac9dd136bfdfb0e43df2c4c5ce1f77dfae"
   integrity sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==
 
+"@types/bluebird@*":
+  version "3.5.36"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.36.tgz#00d9301d4dc35c2f6465a8aec634bb533674c652"
+  integrity sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==
+
 "@types/body-parser@*":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -1213,6 +1218,13 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/redlock@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/redlock/-/redlock-4.0.2.tgz#3ae94bc236d4cff12815b62b9b9e51a8e7f9f25f"
+  integrity sha512-3MMTCWOXrfQFU8dLAbQWDOsftnFagQxmUkfR5KK/DB/zKPUh0ZzPFkNV84nfw1yMFYLfd4MgITGT+XolYd8d1w==
+  dependencies:
+    "@types/bluebird" "*"
 
 "@types/retry@^0.12.0":
   version "0.12.0"
@@ -7641,6 +7653,13 @@ redis-parser@^3.0.0:
   integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
   dependencies:
     redis-errors "^1.0.0"
+
+redlock@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redlock/-/redlock-4.2.0.tgz#c26590768559afd5fff76aa1133c94b411ff4f5f"
+  integrity sha512-j+oQlG+dOwcetUt2WJWttu4CZVeRzUrcVcISFmEmfyuwCVSJ93rDT7YSgg7H7rnxwoRyk/jU46kycVka5tW7jA==
+  dependencies:
+    bluebird "^3.7.2"
 
 regenerator-runtime@^0.13.4:
   version "0.13.7"


### PR DESCRIPTION
Implements locking mechanism using the redlock package (recommended by redis).

The locking works a bit differently than on the main botpress repo. We try taking the lock for about 2 seconds, and if it fails it throws an error.

You can use locking like so :
```ts
// We prefix lock ids with lock_
await this.distributedService.using('lock_my_ressource', async () => {
    await doStuff()
    await doOtherStuff()
})
```

The code in the callback is mostly guaranteed to only be executed on a single node at once.

Closes MES-102