### PR TITLE
fix(twilio): fix legacy validation

### DIFF
--- a/packages/server/src/channels/twilio/channel.ts
+++ b/packages/server/src/channels/twilio/channel.ts
@@ -52,7 +52,7 @@ export class TwilioChannel extends Channel<TwilioConduit> {
     const conduit = await this.app.conduits.get(instance.conduitId)
     const provider = await this.app.providers.getById(conduit!.providerId)
 
-    const oldUrl = `${req.headers['x-bp-host']}/api/v1/bots/${provider!.name}/mod/channel-twilio/webhook`
+    const oldUrl = `${process.env.MASTER_URL}/api/v1/bots/${provider!.name}/mod/channel-twilio/webhook`
 
     return validateRequest(instance.config.authToken, signature, oldUrl, req.body)
   }


### PR DESCRIPTION
This previous fix wasn't working

Fix in main repo https://github.com/botpress/botpress/pull/5269