### PR TITLE
fix(server): run messaging in production when using the binary

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,9 @@ import { Api } from './api'
 import { App } from './app'
 import { Launcher } from './launcher'
 
+// Set NODE_ENV to production when starting messaging using the binary version
+process.env.NODE_ENV = (<any>process).pkg ? 'production' : process.env.NODE_ENV
+
 const router = express()
 
 const app = new App()


### PR DESCRIPTION
This PR sets the value of NODE_ENV to production when running a binary version of the messaging server.

Closes MES-24