### PR TITLE
fix(messenger): fix legacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Botpress messaging repo",
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/server/src/channels/base/channel.ts
+++ b/packages/server/src/channels/base/channel.ts
@@ -37,12 +37,6 @@ export abstract class Channel<TConduit extends ConduitInstance<any, any>> {
     root.use(this.getRoute(), this.asyncMiddleware(this.extractConduit.bind(this)), this.router)
   }
 
-  protected abstract setupRoutes(): Promise<void>
-
-  getRoute(path?: string) {
-    return `/webhooks/:provider/${this.name}${path ? `/${path}` : ''}`
-  }
-
   protected async extractConduit(req: Request, res: Response, next: NextFunction) {
     const providerName = req.params.provider
 
@@ -60,6 +54,10 @@ export abstract class Channel<TConduit extends ConduitInstance<any, any>> {
 
     res.locals.conduit = await this.app.instances.get(conduit.id)
     next()
+  }
+
+  getRoute(path?: string) {
+    return `/webhooks/:provider/${this.name}${path ? `/${path}` : ''}`
   }
 
   protected asyncMiddleware(fn: (req: Request, res: Response, next: NextFunction) => Promise<any>) {
@@ -85,4 +83,5 @@ export abstract class Channel<TConduit extends ConduitInstance<any, any>> {
   }
 
   abstract createConduit(): TConduit
+  protected abstract setupRoutes(): Promise<void>
 }

--- a/packages/server/src/channels/messenger/channel.ts
+++ b/packages/server/src/channels/messenger/channel.ts
@@ -35,6 +35,7 @@ export class MessengerChannel extends Channel<MessengerConduit> {
   }
 
   protected async setupRoot(root: Router) {
+    // json parser needs to be here because extractConduit uses the body to get the pageId
     root.use(this.getRoute(), express.json({ verify: this.prepareAuth.bind(this) }))
     await super.setupRoot(root)
   }

--- a/packages/server/src/channels/messenger/channel.ts
+++ b/packages/server/src/channels/messenger/channel.ts
@@ -35,7 +35,7 @@ export class MessengerChannel extends Channel<MessengerConduit> {
   }
 
   protected async setupRoot(root: Router) {
-    root.use(express.json({ verify: this.prepareAuth.bind(this) }))
+    root.use(this.getRoute(), express.json({ verify: this.prepareAuth.bind(this) }))
     await super.setupRoot(root)
   }
 

--- a/packages/server/src/channels/messenger/channel.ts
+++ b/packages/server/src/channels/messenger/channel.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
-import express, { Response, Request } from 'express'
-import { ServerResponse, IncomingMessage } from 'http'
+import express, { Response, Request, NextFunction, Router } from 'express'
+import { IncomingMessage } from 'http'
+import yn from 'yn'
 import { Channel } from '../base/channel'
 import { MessengerConduit } from './conduit'
 import { MessengerConfigSchema } from './config'
@@ -26,11 +27,22 @@ export class MessengerChannel extends Channel<MessengerConduit> {
     return new MessengerConduit()
   }
 
-  async setupRoutes() {
-    this.router.use(express.json({ verify: this.auth.bind(this) }))
+  // For legacy
+  private pageIdToProviderName: { [pageId: string]: string } = {}
 
+  public registerPageId(pageId: string, providerName: string) {
+    this.pageIdToProviderName[pageId] = providerName
+  }
+
+  protected async setupRoot(root: Router) {
+    root.use(express.json({ verify: this.prepareAuth.bind(this) }))
+    await super.setupRoot(root)
+  }
+
+  protected async setupRoutes() {
     this.router.get(
       '/',
+      this.asyncMiddleware(this.auth.bind(this)),
       this.asyncMiddleware(async (req, res) => {
         await this.handleWebhookVerification(req, res)
       })
@@ -38,12 +50,26 @@ export class MessengerChannel extends Channel<MessengerConduit> {
 
     this.router.post(
       '/',
+      this.asyncMiddleware(this.auth.bind(this)),
       this.asyncMiddleware(async (req, res) => {
         await this.handleMessageRequest(req, res)
       })
     )
 
     this.printWebhook()
+  }
+
+  protected async extractConduit(req: Request, res: Response, next: NextFunction) {
+    if (yn(process.env.SPINNED)) {
+      // When spinned from botpress, it's possible to put anything in the url where the botId should be.
+      // To keep compatibility we need to use the pageId instead to identify a provider
+      if (req.body?.entry?.length) {
+        const pageId = req.body.entry[0].id
+        req.params.provider = this.pageIdToProviderName[pageId] || req.params.provider
+      }
+    }
+
+    return super.extractConduit(req, res, next)
   }
 
   private async handleWebhookVerification(req: Request, res: Response) {
@@ -82,17 +108,21 @@ export class MessengerChannel extends Channel<MessengerConduit> {
     res.send('EVENT_RECEIVED')
   }
 
-  private auth(req: IncomingMessage, res: ServerResponse & Response, buffer: Buffer, _encoding: string) {
+  private async auth(req: Request, res: Response, next: NextFunction) {
     const conduit = res.locals.conduit as MessengerConduit
+    const buffer = res.locals.authBuffer
 
     const signature = req.headers['x-hub-signature'] as string
     const [, hash] = signature.split('=')
     const expectedHash = crypto.createHmac('sha1', conduit.config.appSecret).update(buffer).digest('hex')
     if (hash !== expectedHash) {
-      const message = "Couldn't validate the request signature. Make sure your appSecret is properly configured"
-      this.logger.error(new Error(message))
-
-      throw new Error()
+      throw new Error("Couldn't validate the request signature. Make sure your appSecret is properly configured")
     }
+
+    next()
+  }
+
+  private prepareAuth(req: IncomingMessage, res: Response, buffer: Buffer, _encoding: string) {
+    res.locals.authBuffer = Buffer.from(buffer)
   }
 }

--- a/packages/server/src/channels/messenger/client.ts
+++ b/packages/server/src/channels/messenger/client.ts
@@ -9,7 +9,16 @@ export class MessengerClient {
 
   constructor(private config: MessengerConfig, private logger: Logger) {}
 
-  async setupGetStarted(): Promise<void> {
+  async getPageId() {
+    try {
+      const { data } = await this.http.get('/', { params: { access_token: this.config.accessToken } })
+      return data.id
+    } catch (e) {
+      throw new Error('Error occured fetching page id')
+    }
+  }
+
+  async setupGetStarted() {
     if (!this.config.getStarted) {
       return
     }
@@ -25,7 +34,7 @@ export class MessengerClient {
     }
   }
 
-  async setupGreeting(): Promise<void> {
+  async setupGreeting() {
     if (!this.config.greeting) {
       await this.deleteProfileFields(['greeting'])
       return
@@ -45,7 +54,7 @@ export class MessengerClient {
     }
   }
 
-  async setupPersistentMenu(): Promise<void> {
+  async setupPersistentMenu() {
     if (!this.config.persistentMenu?.length) {
       await this.deleteProfileFields(['persistent_menu'])
       return

--- a/packages/server/src/channels/messenger/conduit.ts
+++ b/packages/server/src/channels/messenger/conduit.ts
@@ -1,7 +1,9 @@
+import yn from 'yn'
 import { ConduitInstance, EndpointContent } from '../base/conduit'
 import { ChannelContext } from '../base/context'
 import { CardToCarouselRenderer } from '../base/renderers/card'
 import { DropdownToChoicesRenderer } from '../base/renderers/dropdown'
+import { MessengerChannel } from './channel'
 import { MessengerClient } from './client'
 import { MessengerConfig } from './config'
 import { MessengerContext } from './context'
@@ -19,6 +21,16 @@ export class MessengerConduit extends ConduitInstance<MessengerConfig, Messenger
 
   protected async setupConnection() {
     this.client = new MessengerClient(this.config, this.logger)
+
+    // Legacy stuff
+    if (yn(process.env.SPINNED)) {
+      const conduit = await this.app.conduits.get(this.conduitId)
+      const provider = await this.app.providers.getById(conduit!.providerId)
+      const channel = this.app.channels.getById(conduit!.channelId) as MessengerChannel
+
+      const pageId = await this.client.getPageId()
+      channel.registerPageId(pageId, provider!.name)
+    }
 
     await this.printWebhook()
   }


### PR DESCRIPTION
It's possible to put anything in the BOT_ID section of the webhook url at the moment and botpress will match the botId using the pageId sent in the body of the requests.

There isn't really a way to handle this on botpress' side so I put some legacy handling code in the messenger channel. It's kind of dirty since the validation needs to be done in two part, because we need the pageId to get the config which is necesarry to validate the request body. The thing is the pageId is in the body, and the body is parsed by the json parser that calls the validate function before parsing the body. So now you have prepareAuth and auth.

Closes MES-120