### PR TITLE
feat(post): added exponential backoff support

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,6 +40,7 @@
     "discord-buttons": "^2.4.1",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
+    "exponential-backoff": "^3.1.0",
     "express": "^4.17.1",
     "ioredis": "^4.27.3",
     "joi": "^17.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4528,6 +4528,11 @@ expect@^27.0.6:
     jest-message-util "^27.0.6"
     jest-regex-util "^27.0.6"
 
+exponential-backoff@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.0.tgz#9409c7e579131f8bd4b32d7d8094a911040f2e68"
+  integrity sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA==
+
 express@^4.0.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
This PR adds exponentials backoff as the retry strategy for the post service. The default number of attempts is 10, but this could be easily configured. I'm open to ideas/criticism!

The formula for the amount of time it gonna take if the call never resolves is: `100 * 2^(n-1)` (where `n` is the number of retries) 

e.g.

With a [jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/):

![Screenshot from 2021-08-10 16-16-27](https://user-images.githubusercontent.com/9640576/128930083-dc2ddc27-5687-4e92-b53a-6f56f7db0d54.png)


Without a jitter:

![Screenshot from 2021-08-10 16-18-05](https://user-images.githubusercontent.com/9640576/128930095-262e35fa-502b-45be-8151-3e43ab371fe1.png)


Closes MES-122