### PR TITLE
fix(messenger): fix webhook validation

### DIFF
--- a/packages/server/src/channels/messenger/channel.ts
+++ b/packages/server/src/channels/messenger/channel.ts
@@ -43,7 +43,6 @@ export class MessengerChannel extends Channel<MessengerConduit> {
   protected async setupRoutes() {
     this.router.get(
       '/',
-      this.asyncMiddleware(this.auth.bind(this)),
       this.asyncMiddleware(async (req, res) => {
         await this.handleWebhookVerification(req, res)
       })


### PR DESCRIPTION
The auth middleware shouldn't be on the webhook verification get route. This caused webhook verification to fail