### PR TITLE
fix(telegram): destroy telegraf

### DIFF
--- a/packages/server/src/channels/telegram/conduit.ts
+++ b/packages/server/src/channels/telegram/conduit.ts
@@ -23,6 +23,10 @@ export class TelegramConduit extends ConduitInstance<TelegramConfig, TelegramCon
     }
   }
 
+  async destroy() {
+    await this.telegraf.stop()
+  }
+
   protected async setupConnection() {
     this.telegraf = new Telegraf(this.config.botToken)
     this.telegraf.start(async (ctx) => {


### PR DESCRIPTION
This PR adds a stop call to telegraf when the instance is destroyed. This prevents a bug where a deleted conduit would have an instance that keeps polling messages and tries to receive messages with that conduit.