### PR TITLE
fix(dockerfile): adapt dockerfile to project references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,34 @@ jobs:
       - name: Build Messaging
         run: |
           yarn build
+
+  # Taken from: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: botpress/messaging:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,21 @@ RUN yarn build
 
 FROM node:12.18.3-alpine
 
-COPY --from=build /messaging/packages/server/dist /messaging/server
-COPY --from=build /messaging/packages/server/package.json /messaging/package.json
-COPY --from=build /messaging/yarn.lock /messaging/yarn.lock
-
 WORKDIR /messaging
 
-RUN yarn --silent --prod
+COPY --from=build /messaging/packages/server/dist packages/server/src
+COPY --from=build /messaging/packages/server/package.json packages/server/package.json
+ 
+COPY --from=build /messaging/packages/base/dist packages/base/dist
+COPY --from=build /messaging/packages/base/package.json packages/base/package.json
+
+COPY --from=build /messaging/package.json package.json
+COPY --from=build /messaging/yarn.lock yarn.lock
+
+
+RUN yarn --silent --prod --frozen-lockfile
 
 ENV NODE_ENV=production
 
 ENTRYPOINT [ "node" ]
-CMD ["./server/index.js"]
+CMD ["./packages/server/src/index.js"]


### PR DESCRIPTION
This PR fixes an issue where the @botpress/messaging-base package could not be found due to the way the dockerfile previously built the project.