### PR TITLE
feat(status): add status service

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -40,10 +40,10 @@ export class App {
   conversations: ConversationService
   messages: MessageService
   mapping: MappingService
+  status: StatusService
   instances: InstanceService
   syncs: SyncService
   health: HealthService
-  status: StatusService
 
   constructor() {
     this.logger = new LoggerService()
@@ -64,15 +64,15 @@ export class App {
     this.conversations = new ConversationService(this.database, this.caching, this.batching, this.users)
     this.messages = new MessageService(this.database, this.caching, this.batching, this.conversations)
     this.mapping = new MappingService(this.database, this.caching, this.batching, this.users, this.conversations)
-    this.status = new StatusService(this.database, this.caching)
+    this.status = new StatusService(this.database, this.distributed, this.caching, this.conduits)
     this.instances = new InstanceService(
       this.logger,
       this.config,
       this.distributed,
       this.caching,
+      this.post,
       this.channels,
       this.providers,
-      this.post,
       this.conduits,
       this.clients,
       this.webhooks,
@@ -124,9 +124,9 @@ export class App {
     await this.conversations.setup()
     await this.messages.setup()
     await this.mapping.setup()
+    await this.status.setup()
     await this.instances.setup()
     await this.health.setup()
-    await this.status.setup()
   }
 
   async monitor() {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -16,6 +16,7 @@ import { MappingService } from './mapping/service'
 import { MessageService } from './messages/service'
 import { PostService } from './post/service'
 import { ProviderService } from './providers/service'
+import { StatusService } from './status/service'
 import { SyncService } from './sync/service'
 import { UserService } from './users/service'
 import { WebhookService } from './webhooks/service'
@@ -42,6 +43,7 @@ export class App {
   instances: InstanceService
   syncs: SyncService
   health: HealthService
+  status: StatusService
 
   constructor() {
     this.logger = new LoggerService()
@@ -62,6 +64,7 @@ export class App {
     this.conversations = new ConversationService(this.database, this.caching, this.batching, this.users)
     this.messages = new MessageService(this.database, this.caching, this.batching, this.conversations)
     this.mapping = new MappingService(this.database, this.caching, this.batching, this.users, this.conversations)
+    this.status = new StatusService(this.database, this.caching)
     this.instances = new InstanceService(
       this.logger,
       this.config,
@@ -76,6 +79,7 @@ export class App {
       this.conversations,
       this.messages,
       this.mapping,
+      this.status,
       this
     )
     this.syncs = new SyncService(
@@ -122,6 +126,7 @@ export class App {
     await this.mapping.setup()
     await this.instances.setup()
     await this.health.setup()
+    await this.status.setup()
   }
 
   async monitor() {

--- a/packages/server/src/instances/invalidator.ts
+++ b/packages/server/src/instances/invalidator.ts
@@ -21,7 +21,7 @@ export class InstanceInvalidator {
     private providers: ProviderService,
     private conduits: ConduitService,
     private clients: ClientService,
-    private statusService: StatusService,
+    private status: StatusService,
     private instances: InstanceService
   ) {}
 
@@ -55,7 +55,7 @@ export class InstanceInvalidator {
 
   private async onConduitUpdated(conduitId: uuid) {
     this.cache.del(conduitId, true)
-    await this.statusService.clearErrors(conduitId)
+    await this.status.clearErrors(conduitId)
 
     const conduit = (await this.conduits.get(conduitId))!
     const channel = this.channels.getById(conduit.channelId)

--- a/packages/server/src/instances/monitoring.ts
+++ b/packages/server/src/instances/monitoring.ts
@@ -15,7 +15,7 @@ export class InstanceMonitoring {
     private distributed: DistributedService,
     private channels: ChannelService,
     private conduits: ConduitService,
-    private statusService: StatusService,
+    private status: StatusService,
     private instances: InstanceService
   ) {}
 
@@ -40,7 +40,8 @@ export class InstanceMonitoring {
     const outdateds = await this.conduits.listOutdated(ms('10h'), 1000)
 
     for (const outdated of outdateds) {
-      if (((await this.statusService.get(outdated.id)) || 0) >= MAX_ALLOWED_FAILURES) {
+      const failures = await this.status.getNumberOfErrors(outdated.id)
+      if (failures && failures >= MAX_ALLOWED_FAILURES) {
         continue
       }
 
@@ -58,7 +59,8 @@ export class InstanceMonitoring {
 
       const conduits = await this.conduits.listByChannel(channel.id)
       for (const conduit of conduits) {
-        if (((await this.statusService.get(conduit.id)) || 0) >= MAX_ALLOWED_FAILURES) {
+        const failures = await this.status.getNumberOfErrors(conduit.id)
+        if (failures && failures >= MAX_ALLOWED_FAILURES) {
           continue
         }
 

--- a/packages/server/src/instances/monitoring.ts
+++ b/packages/server/src/instances/monitoring.ts
@@ -4,6 +4,7 @@ import { ChannelService } from '../channels/service'
 import { ConduitService } from '../conduits/service'
 import { DistributedService } from '../distributed/service'
 import { Logger } from '../logger/types'
+import { StatusService } from '../status/service'
 import { InstanceService } from './service'
 
 const MAX_ALLOWED_FAILURES = 5
@@ -14,8 +15,8 @@ export class InstanceMonitoring {
     private distributed: DistributedService,
     private channels: ChannelService,
     private conduits: ConduitService,
-    private instances: InstanceService,
-    private failures: { [conduitId: string]: number }
+    private statusService: StatusService,
+    private instances: InstanceService
   ) {}
 
   async monitor() {
@@ -39,8 +40,7 @@ export class InstanceMonitoring {
     const outdateds = await this.conduits.listOutdated(ms('10h'), 1000)
 
     for (const outdated of outdateds) {
-      // TODO: replace by StatusService
-      if (this.failures[outdated.id] >= MAX_ALLOWED_FAILURES) {
+      if (((await this.statusService.get(outdated.id)) || 0) >= MAX_ALLOWED_FAILURES) {
         continue
       }
 
@@ -58,8 +58,7 @@ export class InstanceMonitoring {
 
       const conduits = await this.conduits.listByChannel(channel.id)
       for (const conduit of conduits) {
-        // TODO: replace by StatusService
-        if (this.failures[conduit.id] >= MAX_ALLOWED_FAILURES) {
+        if (((await this.statusService.get(conduit.id)) || 0) >= MAX_ALLOWED_FAILURES) {
           continue
         }
 

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -49,9 +49,9 @@ export class InstanceService extends Service {
     private configService: ConfigService,
     private distributedService: DistributedService,
     private cachingService: CachingService,
+    private postService: PostService,
     private channelService: ChannelService,
     private providerService: ProviderService,
-    private postService: PostService,
     private conduitService: ConduitService,
     private clientService: ClientService,
     private webhookService: WebhookService,
@@ -155,6 +155,7 @@ export class InstanceService extends Service {
     }
 
     await this.conduitService.updateInitialized(conduitId)
+    await this.statusService.clearErrors(conduitId)
     return this.emitter.emit(InstanceEvents.Initialized, conduitId)
   }
 

--- a/packages/server/src/status/service.ts
+++ b/packages/server/src/status/service.ts
@@ -1,0 +1,71 @@
+import { uuid } from '@botpress/messaging-base'
+import { v4 as uuidv4 } from 'uuid'
+import { Service } from '../base/service'
+import { ServerCache } from '../caching/cache'
+import { CachingService } from '../caching/service'
+import { DatabaseService } from '../database/service'
+import { StatusTable } from './table'
+
+export class StatusService extends Service {
+  private table: StatusTable
+  private cache!: ServerCache<uuid, number>
+
+  constructor(private db: DatabaseService, private cachingService: CachingService) {
+    super()
+    this.table = new StatusTable()
+  }
+
+  async setup() {
+    this.cache = await this.cachingService.newServerCache('cache_nb_error_by_conduit')
+
+    await this.db.registerTable(this.table)
+  }
+
+  public async get(conduitId: uuid): Promise<number | undefined> {
+    const cached = this.cache.get(conduitId)
+    if (cached) {
+      return cached
+    }
+
+    const rows = await this.query().where({ conduitId })
+    if (rows?.length) {
+      const numberOfErrors = rows[0]['numberOfErrors']
+
+      this.cache.set(conduitId, numberOfErrors)
+
+      return numberOfErrors
+    }
+
+    return undefined
+  }
+
+  async addError(conduitId: uuid, error: Error) {
+    const numberOfErrors = await this.get(conduitId)
+
+    if (numberOfErrors === undefined) {
+      await this.query().insert({ id: uuidv4(), conduitId, numberOfErrors: 1, lastError: error })
+
+      this.cache.set(conduitId, 1)
+    } else {
+      await this.query()
+        .update({ numberOfErrors: numberOfErrors + 1, lastError: error })
+        .where({ conduitId })
+
+      this.cache.set(conduitId, numberOfErrors + 1)
+    }
+  }
+
+  async clearErrors(conduitId: uuid) {
+    const numberOfErrors = await this.get(conduitId)
+
+    if (numberOfErrors && numberOfErrors > 0) {
+      await this.query().update({ numberOfErrors: 0, lastError: null }).where({ conduitId })
+
+      this.cache.set(conduitId, 0)
+    }
+  }
+
+  private query() {
+    return this.db.knex(this.table.id)
+  }
+}

--- a/packages/server/src/status/service.ts
+++ b/packages/server/src/status/service.ts
@@ -39,7 +39,7 @@ export class StatusService extends Service {
     if (rows?.length) {
       const numberOfErrors = rows[0].numberOfErrors
 
-      this.cache.set(conduitId, numberOfErrors, undefined, true)
+      this.cache.set(conduitId, numberOfErrors)
 
       return numberOfErrors
     }
@@ -83,11 +83,7 @@ export class StatusService extends Service {
   }
 
   private async onConduitDeleted(conduitId: string) {
-    if (this.cache.has(conduitId)) {
-      await this.query().delete().where({ conduitId })
-
-      this.cache.del(conduitId, true)
-    }
+    this.cache.del(conduitId, true)
   }
 
   private formatError(error: Error) {

--- a/packages/server/src/status/table.ts
+++ b/packages/server/src/status/table.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex'
+import { Table } from '../base/table'
+
+export class StatusTable extends Table {
+  get id() {
+    return 'msg_status'
+  }
+
+  create(table: Knex.CreateTableBuilder) {
+    table.uuid('id').primary()
+    table.uuid('conduitId').references('id').inTable('msg_conduits').notNullable().onDelete('cascade')
+    table.integer('numberOfErrors').defaultTo(0)
+    table.text('lastError')
+    table.index(['conduitId'])
+  }
+}

--- a/packages/server/src/status/table.ts
+++ b/packages/server/src/status/table.ts
@@ -7,9 +7,8 @@ export class StatusTable extends Table {
   }
 
   create(table: Knex.CreateTableBuilder) {
-    table.uuid('conduitId').references('id').inTable('msg_conduits').onDelete('cascade')
+    table.uuid('conduitId').primary().references('id').inTable('msg_conduits').onDelete('cascade')
     table.integer('numberOfErrors').defaultTo(0)
     table.text('lastError')
-    table.primary(['conduitId'])
   }
 }

--- a/packages/server/src/status/table.ts
+++ b/packages/server/src/status/table.ts
@@ -7,10 +7,9 @@ export class StatusTable extends Table {
   }
 
   create(table: Knex.CreateTableBuilder) {
-    table.uuid('id').primary()
-    table.uuid('conduitId').references('id').inTable('msg_conduits').notNullable().onDelete('cascade')
+    table.uuid('conduitId').references('id').inTable('msg_conduits').onDelete('cascade')
     table.integer('numberOfErrors').defaultTo(0)
     table.text('lastError')
-    table.index(['conduitId'])
+    table.primary(['conduitId'])
   }
 }


### PR DESCRIPTION
This PR adds the structure for the new status service and makes sure to use this service instead of the in-memory conduit failure count.

Note: This PR creates a new table (msg_status)

Unit tests will be made in another PR.