### PR TITLE
fix(post): stop retrying request when server is shutting down

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -130,6 +130,7 @@ export class App {
   }
 
   async destroy() {
+    await this.post?.destroy()
     await this.batching?.destroy()
     await this.instances?.destroy()
     await this.distributed?.destroy()


### PR DESCRIPTION
This PR fixes an issue where the post service could still retry multiple times a certain request when the server is shutting down.