### PR TITLE
fix(health): send configure event when created

### DIFF
--- a/packages/server/src/health/watcher.ts
+++ b/packages/server/src/health/watcher.ts
@@ -29,6 +29,7 @@ export class HealthWatcher {
 
   private async handleConduitCreated(conduitId: uuid) {
     await this.healthService.register(conduitId, HealthEventType.Create)
+    await this.healthService.register(conduitId, HealthEventType.Configure)
   }
 
   private async handleConduitUpdated(conduitId: uuid) {


### PR DESCRIPTION
This adds a `configure` when creating a conduit. That way the `configure` event of health reports all changes in configuration, including the creation of the config.

Closes MES-135