### PR TITLE
fix(ci_cd): fix changelog generation on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '12.18.3'
           cache: 'yarn'
-      - name: Git Unshalow
+      - name: Git Unshallow
         run: git fetch --prune --unshallow
       - name: Fetch Node Packages
         run: |

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -20,8 +20,8 @@ const build = async ({ writeToFile } = { writeToFile: false }) => {
 
   let text = ''
   const stream = changelog(changelogOts, context, gitRawCommitsOpts, commitsParserOpts, changelogWriterOpts)
-  stream.on('data', chunk => (text += chunk))
-  await Promise.fromCallback(cb => stream.on('end', cb))
+  stream.on('data', (chunk) => (text += chunk))
+  await Promise.fromCallback((cb) => stream.on('end', cb))
 
   if (writeToFile) {
     const existingChangelog = await fse.readFile('./CHANGELOG.md', 'utf-8')

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,13 +1,13 @@
+const { execute } = require('./exec')
 const semver = require('semver')
 const yargs = require('yargs')
 const fse = require('fs-extra')
-const { spawn } = require('child_process')
 const path = require('path')
 const changelog = require('./changelog')
 const logger = require('./logger')
 
 yargs
-  .command(['$0 <releaseType>'], 'Bump release version. releaseType options: major, minor, patch', {}, async argv => {
+  .command(['$0 <releaseType>'], 'Bump release version. releaseType options: major, minor, patch', {}, async (argv) => {
     yargs.positional('releaseType', {
       describe: 'Type of release to do: major, minor or patch',
       type: 'string',
@@ -18,13 +18,12 @@ yargs
       const version = (await fse.readJSON(path.join('package.json'))).version
       const newVersion = semver.inc(version, argv.releaseType)
 
+      const bumpCommand = `version --new-version ${newVersion} --no-git-tag-version`
+      await execute(`yarn ${bumpCommand}`, undefined, { silent: true })
+      await execute(`yarn workspace @botpress/messaging-server ${bumpCommand}`, undefined, { silent: true })
+
       const changes = await changelog.build({ writeToFile: true })
       logger.info(`Change Log:\n\n${changes}`)
-
-      spawn('yarn', ['version', '--new-version', newVersion, '--no-git-tag-version'], {
-        stdio: 'inherit',
-        shell: true
-      })
     } catch (err) {
       logger.error(err)
     }


### PR DESCRIPTION
This PR fixes CHANGELOG generation on new release. 

The process is now as follows:

```sh
// Create a new branch from an up-to-date master
git checkout -b vX_X_X
// Run yarn release to bump the package.json version and generate a changelog
yarn release <major|minor|patch>
// Commit the changes and push the branch and create a pull request
git add .
git commit -m "vX_X_X"
git push origin vX_X_X
```

See https://github.com/botpress/messaging/pull/147

Closes MES-37