### PR TITLE
fix(post): log errors as warnings

### DIFF
--- a/packages/server/src/post/service.ts
+++ b/packages/server/src/post/service.ts
@@ -14,7 +14,7 @@ export class PostService extends Service {
 
   constructor(private configService: ConfigService) {
     super()
-    this.logger = new Logger('post')
+    this.logger = new Logger('Post')
     this.isTerminating = false
   }
 
@@ -53,7 +53,9 @@ export class PostService extends Service {
         }
       })
     } catch (e) {
-      this.logger.error(e, `An error occurred calling route ${url}. Total number of attempts: ${this.attempts}`)
+      this.logger.warn(
+        `An error occurred calling route ${url}. Total number of attempts: ${this.attempts}. ${e.message}`
+      )
     }
   }
 }

--- a/packages/server/src/post/service.ts
+++ b/packages/server/src/post/service.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios'
+import clc from 'cli-color'
 import { backOff } from 'exponential-backoff'
 
 import { Service } from '../base/service'
@@ -54,7 +55,9 @@ export class PostService extends Service {
       })
     } catch (e) {
       this.logger.warn(
-        `An error occurred calling route ${url}. Total number of attempts: ${this.attempts}. ${e.message}`
+        `Unabled to reach webhook after ${this.attempts} attempts ${clc.blackBright(url)} ${clc.blackBright(
+          `Error: ${e.message}`
+        )}`
       )
     }
   }

--- a/packages/server/test/post/service.test.ts
+++ b/packages/server/test/post/service.test.ts
@@ -132,14 +132,13 @@ describe('PostService', () => {
         writable: false
       })
 
-      const loggerSpy = jest.spyOn(postService['logger'], 'error')
+      const loggerSpy = jest.spyOn(postService['logger'], 'warn')
 
       await postService.send(url, data)
 
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(url, data, axiosConfig)
       expect(loggerSpy).toBeCalledTimes(1)
-      expect(loggerSpy).toBeCalledWith(error, expect.anything())
     })
 
     describe('destroy', () => {
@@ -154,7 +153,7 @@ describe('PostService', () => {
           writable: false
         })
 
-        const loggerSpy = jest.spyOn(postService['logger'], 'error')
+        const loggerSpy = jest.spyOn(postService['logger'], 'warn')
 
         await postService.destroy()
         await postService.send(url, data)
@@ -162,7 +161,6 @@ describe('PostService', () => {
         expect(spy).toHaveBeenCalledTimes(1)
         expect(spy).toHaveBeenCalledWith(url, data, axiosConfig)
         expect(loggerSpy).toBeCalledTimes(1)
-        expect(loggerSpy).toBeCalledWith(error, expect.anything())
       })
     })
   })


### PR DESCRIPTION
I my opinion webhook "errors" are not really server errors. So I changed the log status to be warnings.

Closes MES-144