### PR TITLE
chore(docker): moved all parts of start command to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ RUN yarn --silent --prod --frozen-lockfile
 
 ENV NODE_ENV=production
 
-ENTRYPOINT [ "node" ]
-CMD ["./packages/server/src/index.js"]
+ENTRYPOINT [ "node", "./packages/server/src/index.js" ]
+CMD []


### PR DESCRIPTION
This PR allows for any users of the Dockerfile to override the command that is passed to the container without having to specify the path to the server's entry point (`./packages/server/src/index.js`).

This way, you can start the container like so:

`docker run -it --rm --name messaging messaging:latest --auto-migrate`