### PR TITLE
chore(server): disable graceful shutdown when messaging is spinned from botpress

### DIFF
--- a/packages/server/src/launcher.ts
+++ b/packages/server/src/launcher.ts
@@ -88,20 +88,16 @@ export class Launcher {
   }
 
   async shutDown(code?: number) {
-    if (!this.shuttingDown) {
+    if (!this.shuttingDown && !yn(process.env.SPINNED)) {
       this.shuttingDown = true
 
-      if (!yn(process.env.SPINNED)) {
-        this.logger.info('Server gracefully closing down...')
-      }
+      this.logger.info('Server gracefully closing down...')
 
       await this.api.sockets.destroy()
       await this.httpTerminator?.terminate()
       await this.app.destroy()
 
-      if (!yn(process.env.SPINNED)) {
-        this.logger.info('Server shutdown complete')
-      }
+      this.logger.info('Server shutdown complete')
     }
     process.exit(code)
   }


### PR DESCRIPTION
This PR fixes an issue where Botpress would be terminated and messaging would still run when Botpress is closed because it tries to gracefully shut down.