### PR TITLE
chore(tests): integration tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     sourceType: 'module'
   },
-  ignorePatterns: ['**/*.test.ts', '*.js', '**/dist/**'],
+  ignorePatterns: ['*.js', '**/dist/**'],
   plugins: ['eslint-plugin-import', 'eslint-plugin-jsdoc', '@typescript-eslint'],
   rules: {
     '@typescript-eslint/consistent-type-definitions': 'error',

--- a/packages/server/test/database.test.ts
+++ b/packages/server/test/database.test.ts
@@ -1,13 +1,13 @@
-import _ from 'lodash'
 import fs from 'fs'
+import { Knex } from 'knex'
+import _ from 'lodash'
 import * as path from 'path'
 import { mocked } from 'ts-jest/utils'
 
-import { DatabaseService } from '../../src/database/service'
-import { Table } from '../../src/base/table'
-import { Knex } from 'knex'
+import { Table } from '../src/base/table'
+import { DatabaseService } from '../src/database/service'
 
-jest.mock('../../src/logger/types')
+jest.mock('../src/logger/types')
 jest.mock('fs')
 jest.mock('knex', () => {
   const mKnexSchema = { hasTable: jest.fn(), createTable: jest.fn() }

--- a/packages/server/test/logger.test.ts
+++ b/packages/server/test/logger.test.ts
@@ -1,6 +1,6 @@
 import clc from 'cli-color'
 import _ from 'lodash'
-import { Logger } from '../../src/logger/types'
+import { Logger } from '../src/logger/types'
 
 describe('Logger', () => {
   const defaultEnv = process.env
@@ -62,8 +62,8 @@ describe('Logger', () => {
       const spy = jest.spyOn(console, 'log').mockImplementation()
 
       for (const level of levels) {
-        let params: any[] = [message, data]
-        let outputParams: any[] = [expect.anything(), expect.stringContaining(scope), message, data]
+        const params: any[] = [message, data]
+        const outputParams: any[] = [expect.anything(), expect.stringContaining(scope), message, data]
 
         if (level === 'error') {
           params.unshift(error)
@@ -84,8 +84,8 @@ describe('Logger', () => {
       const spy = jest.spyOn(console, 'log').mockImplementation()
 
       for (const level of levels) {
-        let params: any[] = [message]
-        let outputParams: any[] = [expect.anything(), expect.stringContaining(scope), message]
+        const params: any[] = [message]
+        const outputParams: any[] = [expect.anything(), expect.stringContaining(scope), message]
 
         if (level === 'error') {
           params.unshift(error)
@@ -106,8 +106,8 @@ describe('Logger', () => {
       const spy = jest.spyOn(console, 'log').mockImplementation()
 
       for (const level of levels) {
-        let params: any[] = [message, data]
-        let outputParams: any[] = [expect.anything(), expect.stringContaining(scope), prefixedMessage, data]
+        const params: any[] = [message, data]
+        const outputParams: any[] = [expect.anything(), expect.stringContaining(scope), prefixedMessage, data]
 
         if (level === 'error') {
           params.unshift(error)
@@ -130,8 +130,8 @@ describe('Logger', () => {
       const spy = jest.spyOn(console, 'log').mockImplementation()
 
       for (const level of levels) {
-        let params: any[] = [message]
-        let outputParams: any[] = [expect.anything(), expect.stringContaining(`[Messaging] ${scope}`), message]
+        const params: any[] = [message]
+        const outputParams: any[] = [expect.anything(), expect.stringContaining(`[Messaging] ${scope}`), message]
 
         if (level === 'error') {
           params.unshift(error)
@@ -154,8 +154,8 @@ describe('Logger', () => {
       const spy = jest.spyOn(console, 'log').mockImplementation()
 
       for (const level of levels) {
-        let params: any[] = [message, data]
-        let outputParams: any[] = [expect.anything(), expect.stringContaining(scope), ...logger['singleLine'](params)]
+        const params: any[] = [message, data]
+        const outputParams: any[] = [expect.anything(), expect.stringContaining(scope), ...logger['singleLine'](params)]
 
         if (level === 'error') {
           params.unshift(error)
@@ -177,7 +177,7 @@ describe('Logger', () => {
       const logger = new Logger(scope)
       const spy = jest.spyOn(console, 'log').mockImplementation()
 
-      let circularObj = {}
+      const circularObj: any = {}
       circularObj['a'] = circularObj
 
       logger.info(message, circularObj)

--- a/packages/server/test/post.test.ts
+++ b/packages/server/test/post.test.ts
@@ -1,9 +1,9 @@
-import _ from 'lodash'
 import axios, { AxiosRequestConfig } from 'axios'
+import _ from 'lodash'
 
-import { PostService } from '../../src/post/service'
+import { PostService } from '../src/post/service'
 
-jest.mock('../../src/logger/types')
+jest.mock('../src/logger/types')
 jest.mock('axios')
 
 describe('PostService', () => {

--- a/packages/server/test/providers.test.ts
+++ b/packages/server/test/providers.test.ts
@@ -1,0 +1,52 @@
+import crypto from 'crypto'
+import { ProviderService } from '../src/providers/service'
+import { Provider } from '../src/providers/types'
+import { getApp } from './util/app'
+
+describe('Providers', () => {
+  let providers: ProviderService
+  const state: { provider?: Provider } = {}
+
+  beforeAll(async () => {
+    providers = (await getApp()).providers
+  })
+
+  afterAll(async () => {
+    await (await getApp()).destroy()
+  })
+
+  test('Create provider', async () => {
+    const name = crypto.randomBytes(66).toString('base64')
+    const provider = await providers.create(name, false)
+
+    expect(provider).toBeDefined()
+    expect(provider.name).toBe(name)
+    expect(provider.sandbox).toBeFalsy()
+
+    state.provider = provider
+  })
+
+  test('Get provider by id', async () => {
+    const provider = await providers.getById(state.provider!.id)
+    expect(provider).toEqual(state.provider)
+  })
+
+  test('Get provider by name', async () => {
+    const provider = await providers.getByName(state.provider!.name)
+    expect(provider).toEqual(state.provider)
+  })
+
+  test('Delete provider', async () => {
+    await providers.delete(state.provider!.id)
+  })
+
+  test('Deleted provider cannot be fetched by id', async () => {
+    const provider = await providers.getById(state.provider!.id)
+    expect(provider).toBeUndefined()
+  })
+
+  test('Deleted provider cannot be fetched by name', async () => {
+    const provider = await providers.getByName(state.provider!.name)
+    expect(provider).toBeUndefined()
+  })
+})

--- a/packages/server/test/sync.test.ts
+++ b/packages/server/test/sync.test.ts
@@ -1,10 +1,10 @@
 import cloneDeep from 'lodash/cloneDeep'
 
-import { ChannelService } from '../../src/channels/service'
-import { DatabaseService } from '../../src/database/service'
-import { makeSyncRequestSchema } from '../../src/sync/schema'
+import { ChannelService } from '../src/channels/service'
+import { DatabaseService } from '../src/database/service'
+import { makeSyncRequestSchema } from '../src/sync/schema'
 
-jest.mock('../../src/database/service')
+jest.mock('../src/database/service')
 
 const channels = {
   messenger: {

--- a/packages/server/test/tsconfig.json
+++ b/packages/server/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.packages.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["../test/**/*", "../src/**/*"]
+}

--- a/packages/server/test/util/app.ts
+++ b/packages/server/test/util/app.ts
@@ -1,0 +1,15 @@
+import { App } from '../../src/app'
+
+let app: App
+
+export const getApp = async () => {
+  if (app) {
+    return app
+  }
+
+  process.env.DATABASE_URL = ''
+
+  app = new App()
+  await app.setup()
+  return app
+}


### PR DESCRIPTION
WIP

I fixed some of the setup for tests. Eslint wasn't working because .test.ts files were ignored. I added a dummy tsconfig.json in the test directory to make auto-imports work.

With these changes I corrected the eslint problems in the old tests. I also moved all the tests in the root test directory. We'll put some test suites in their own folders if needed, but for now this is more useable.

I added tests for the provider service, which create and setup an app. This is the start of the "integration" tests, which I expect will be way more common than unit tests, since mostly everything that we do in messaging is communicating with the db. These tests will also need to test caching somehow (probably by spying call to the query function of a service).