### PR TITLE
fix(slack): slack image rendered requires text in title

### DIFF
--- a/packages/server/src/channels/slack/renderers/image.ts
+++ b/packages/server/src/channels/slack/renderers/image.ts
@@ -8,7 +8,7 @@ export class SlackImageRenderer extends ImageRenderer {
       type: 'image',
       title: {
         type: 'plain_text',
-        text: payload.title || 'image_title'
+        text: payload.title ?? 'image_title'
       },
       image_url: payload.image,
       alt_text: 'image'


### PR DESCRIPTION
The [documentation](https://api.slack.com/reference/block-kit/block-elements#image) makes no mention of the title property, but the error message as copy/pasted in this issue (#182) clearly states the `text` property is `undefined`. There was a null-assertion, so I removed it and added a fallback.