### PR TITLE
fix(channels): fix typing indicators always on

### DIFF
--- a/packages/server/src/channels/base/senders/typing.ts
+++ b/packages/server/src/channels/base/senders/typing.ts
@@ -8,7 +8,7 @@ export class TypingSender implements ChannelSender<any> {
 
   handles(context: ChannelContext<any>): boolean {
     const typing = context.payload.typing
-    return context.handlers > 0 && (typing === undefined || typing === true)
+    return context.handlers > 0 && typing === true
   }
 
   async send(context: ChannelContext<any>): Promise<void> {


### PR DESCRIPTION
This PR fixes an issue where typing indicators were always sent to channels. Since `context.payload.typing` can only take two values (`undefined = unchecked | true = checked`), the condition for the handler was always true even when the checkbox (`Show typing indicators`) was unchecked.