### PR TITLE
chore(server): fix serving the server version

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -65,7 +65,7 @@ export class Api {
     await this.setupPassword()
 
     this.root.get('/version', this.version.bind(this))
-    this.root.get('/status', this.status)
+    this.root.get('/status', this.status.bind(this))
     this.root.use('/api', this.router)
     this.router.use(cors())
     this.router.use(express.json())


### PR DESCRIPTION
This PR fixes an issue where calling `/version` would return an internal serve error due to `this` being undefined in the handler. Binding `this` to the handler solves the issue.


![Screenshot from 2021-10-28 12-00-58](https://user-images.githubusercontent.com/9640576/139293004-3086f656-fc16-4370-990e-854377fc4c7f.png)
