### PR TITLE
fix(build): unnecessary params for Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,5 @@ jobs:
       - uses: ./@actions/build/docker
         with:
           repository: messaging
-          aws-ecr-policy: '${{ secrets.AWS_ECR_POLICY }}'
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ROLE }}


### PR DESCRIPTION
The new version of the Docker build action does not require these params