### PR TITLE
fix(monitoring): fix timeout not being cleared

### DIFF
--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -102,6 +102,8 @@ export class InstanceService extends Service {
   async destroy() {
     this.destroyed = true
 
+    await this.monitoring.destroy()
+
     if (!this.cache) {
       return
     }


### PR DESCRIPTION
The timeout for the monitoring wasn't deleted when the server was closes, so now it is.

Closes DEV-1633