### PR TITLE
fix(mapping): fix insert race conditions

### DIFF
--- a/packages/engine/src/barrier/barrier.ts
+++ b/packages/engine/src/barrier/barrier.ts
@@ -1,0 +1,20 @@
+import { ServerCache2D } from '../caching/cache2D'
+
+export class Barrier2D<T> {
+  constructor(private id: string, private locks: ServerCache2D<Promise<T>>) {}
+
+  async once(keyX: string, keyY: string, callback: () => Promise<T>): Promise<T> {
+    let promise = this.locks.get(keyX, keyY)
+
+    if (!promise) {
+      promise = new Promise(async (resolve) => {
+        resolve(await callback())
+        this.locks.del(keyX, keyY)
+      })
+
+      this.locks.set(keyX, keyY, promise)
+    }
+
+    return promise
+  }
+}

--- a/packages/engine/src/barrier/service.ts
+++ b/packages/engine/src/barrier/service.ts
@@ -1,0 +1,16 @@
+import { Service } from '../base/service'
+import { CachingService } from '../caching/service'
+import { Barrier2D } from './barrier'
+
+export class BarrierService extends Service {
+  constructor(private caching: CachingService) {
+    super()
+  }
+
+  async setup() {}
+
+  async newBarrier2D<T>(id: string): Promise<Barrier2D<T>> {
+    const locks = await this.caching.newServerCache2D<Promise<T>>(`cache_locks_${id}`)
+    return new Barrier2D(id, locks)
+  }
+}

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,4 +1,5 @@
 import { DispatchService } from '.'
+import { BarrierService } from './barrier/service'
 import { BatchingService } from './batching/service'
 import { CachingService } from './caching/service'
 import { CryptoService } from './crypto/service'
@@ -19,6 +20,7 @@ export class Engine {
   dispatches: DispatchService
   caching: CachingService
   batching: BatchingService
+  barriers: BarrierService
   kvs: KvsService
 
   constructor() {
@@ -31,6 +33,7 @@ export class Engine {
     this.dispatches = new DispatchService(this.distributed)
     this.caching = new CachingService(this.distributed)
     this.batching = new BatchingService()
+    this.barriers = new BarrierService(this.caching)
     this.kvs = new KvsService(this.database, this.caching)
   }
 
@@ -44,6 +47,7 @@ export class Engine {
     await this.dispatches.setup()
     await this.caching.setup()
     await this.batching.setup()
+    await this.barriers.setup()
     await this.kvs.setup()
   }
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,3 +1,5 @@
+export * from './barrier/barrier'
+export * from './barrier/service'
 export * from './base/errors'
 export * from './base/service'
 export * from './base/table'

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -52,7 +52,14 @@ export class App extends Engine {
     this.conversations = new ConversationService(this.database, this.caching, this.batching, this.users)
     this.messages = new MessageService(this.database, this.caching, this.batching, this.conversations)
     this.converse = new ConverseService(this.caching, this.dispatches, this.messages)
-    this.mapping = new MappingService(this.database, this.caching, this.batching, this.users, this.conversations)
+    this.mapping = new MappingService(
+      this.database,
+      this.caching,
+      this.batching,
+      this.barriers,
+      this.users,
+      this.conversations
+    )
     this.status = new StatusService(this.database, this.distributed, this.caching, this.conduits)
     this.instances = new InstanceService(
       this.logger,

--- a/packages/server/src/mapping/convmap/service.ts
+++ b/packages/server/src/mapping/convmap/service.ts
@@ -97,6 +97,18 @@ export class ConvmapService extends Service {
     return convmaps
   }
 
+  // TODO: remove clientId from param list
+  async map(tunnelId: uuid, threadId: uuid, clientId: uuid, userId: uuid): Promise<uuid> {
+    const convmap = await this.getByThreadId(tunnelId, threadId)
+    let conversationId = convmap?.conversationId
+    if (!conversationId) {
+      conversationId = (await this.conversations.create(clientId, userId)).id
+      await this.create(tunnelId, conversationId, threadId)
+    }
+
+    return conversationId
+  }
+
   private query() {
     return this.db.knex(this.table.id)
   }

--- a/packages/server/src/mapping/convmap/service.ts
+++ b/packages/server/src/mapping/convmap/service.ts
@@ -10,6 +10,7 @@ import {
 } from '@botpress/messaging-engine'
 import { ConversationService } from '../../conversations/service'
 import { ThreadService } from '../threads/service'
+import { TunnelService } from '../tunnels/service'
 import { ConvmapTable } from './table'
 import { Convmap } from './types'
 
@@ -26,6 +27,7 @@ export class ConvmapService extends Service {
     private caching: CachingService,
     private batching: BatchingService,
     private conversations: ConversationService,
+    private tunnels: TunnelService,
     private threads: ThreadService
   ) {
     super()
@@ -99,8 +101,7 @@ export class ConvmapService extends Service {
     return convmaps
   }
 
-  // TODO: remove clientId from param list
-  async map(tunnelId: uuid, threadId: uuid, clientId: uuid, userId: uuid): Promise<Convmap> {
+  async map(tunnelId: uuid, threadId: uuid, userId: uuid): Promise<Convmap> {
     const convmap = await this.getByThreadId(tunnelId, threadId)
 
     if (!convmap) {
@@ -108,7 +109,8 @@ export class ConvmapService extends Service {
 
       if (!promise) {
         promise = new Promise(async (resolve) => {
-          const conversation = await this.conversations.create(clientId, userId)
+          const tunnel = await this.tunnels.get(tunnelId)
+          const conversation = await this.conversations.create(tunnel!.clientId, userId)
           const convmap = await this.create(tunnelId, conversation.id, threadId)
 
           resolve(convmap)

--- a/packages/server/src/mapping/senders/service.ts
+++ b/packages/server/src/mapping/senders/service.ts
@@ -13,10 +13,12 @@ import { SenderTable } from './table'
 import { Sender } from './types'
 
 export class SenderService extends Service {
+  public batcher!: Batcher<Sender>
+
   private table: SenderTable
   private cacheById!: ServerCache<uuid, Sender>
   private cacheByName!: ServerCache2D<Sender>
-  public batcher!: Batcher<Sender>
+  private locks!: ServerCache2D<Promise<Sender>>
 
   constructor(private db: DatabaseService, private caching: CachingService, private batching: BatchingService) {
     super()
@@ -26,6 +28,7 @@ export class SenderService extends Service {
   async setup() {
     this.cacheById = await this.caching.newServerCache('cache_sender_by_id')
     this.cacheByName = await this.caching.newServerCache2D('cache_sender_by_name')
+    this.locks = await this.caching.newServerCache2D('cache_sender_locks')
 
     this.batcher = await this.batching.newBatcher('batcher_sender', [], this.handleBatchFlush.bind(this))
 
@@ -68,17 +71,28 @@ export class SenderService extends Service {
       this.cacheByName.set(identityId, name, sender)
       return sender
     } else {
-      const sender = {
-        id: uuidv4(),
-        identityId,
-        name
+      let promise = this.locks.get(identityId, name)
+
+      if (!promise) {
+        promise = new Promise(async (resolve) => {
+          const sender = {
+            id: uuidv4(),
+            identityId,
+            name
+          }
+
+          await this.batcher.push(sender)
+          this.cacheByName.set(identityId, name, sender)
+          this.cacheById.set(sender.id, sender)
+
+          resolve(sender)
+          this.locks.del(identityId, name)
+        })
+
+        this.locks.set(identityId, name, promise)
       }
 
-      await this.batcher.push(sender)
-      this.cacheByName.set(identityId, name, sender)
-      this.cacheById.set(sender.id, sender)
-
-      return sender
+      return promise
     }
   }
 

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -1,5 +1,5 @@
 import { uuid } from '@botpress/messaging-base'
-import { BatchingService, CachingService, DatabaseService, Service } from '@botpress/messaging-engine'
+import { BarrierService, BatchingService, CachingService, DatabaseService, Service } from '@botpress/messaging-engine'
 import { ConversationService } from '../conversations/service'
 import { UserService } from '../users/service'
 import { ConvmapService } from './convmap/service'
@@ -24,6 +24,7 @@ export class MappingService extends Service {
     private db: DatabaseService,
     private caching: CachingService,
     private batching: BatchingService,
+    private barriers: BarrierService,
     private users: UserService,
     private conversations: ConversationService
   ) {
@@ -38,6 +39,7 @@ export class MappingService extends Service {
       this.db,
       this.caching,
       this.batching,
+      this.barriers,
       this.conversations,
       this.tunnels,
       this.threads

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -30,7 +30,7 @@ export class MappingService extends Service {
   ) {
     super()
 
-    this.tunnels = new TunnelService(this.db, this.caching)
+    this.tunnels = new TunnelService(this.db, this.caching, this.barriers)
     this.identities = new IdentityService(this.db, this.caching)
     this.senders = new SenderService(this.db, this.caching, this.batching)
     this.threads = new ThreadService(this.db, this.caching, this.batching, this.senders)

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -34,7 +34,15 @@ export class MappingService extends Service {
     this.identities = new IdentityService(this.db, this.caching)
     this.senders = new SenderService(this.db, this.caching, this.batching)
     this.threads = new ThreadService(this.db, this.caching, this.batching, this.senders)
-    this.usermap = new UsermapService(this.db, this.caching, this.batching, this.users, this.tunnels, this.senders)
+    this.usermap = new UsermapService(
+      this.db,
+      this.caching,
+      this.batching,
+      this.barriers,
+      this.users,
+      this.tunnels,
+      this.senders
+    )
     this.convmap = new ConvmapService(
       this.db,
       this.caching,

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -53,16 +53,16 @@ export class MappingService extends Service {
     const identity = await this.identities.map(tunnel.id, endpoint.identity || '*')
     const sender = await this.senders.map(identity.id, endpoint.sender || '*')
     const thread = await this.threads.map(sender.id, endpoint.thread || '*')
-    const userId = await this.usermap.map(tunnel.id, sender.id, clientId)
-    const conversationId = await this.convmap.map(tunnel.id, thread.id, clientId, userId)
+    const usermap = await this.usermap.map(tunnel.id, sender.id, clientId)
+    const convmap = await this.convmap.map(tunnel.id, thread.id, clientId, usermap.userId)
 
     return {
       tunnelId: tunnel.id,
       identityId: identity.id,
       senderId: sender.id,
       threadId: thread.id,
-      userId,
-      conversationId
+      userId: usermap.userId,
+      conversationId: convmap.conversationId
     }
   }
 

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -33,7 +33,7 @@ export class MappingService extends Service {
     this.tunnels = new TunnelService(this.db, this.caching, this.barriers)
     this.identities = new IdentityService(this.db, this.caching, this.barriers)
     this.senders = new SenderService(this.db, this.caching, this.batching, this.barriers)
-    this.threads = new ThreadService(this.db, this.caching, this.batching, this.senders)
+    this.threads = new ThreadService(this.db, this.caching, this.batching, this.barriers, this.senders)
     this.usermap = new UsermapService(
       this.db,
       this.caching,

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -53,20 +53,8 @@ export class MappingService extends Service {
     const identity = await this.identities.map(tunnel.id, endpoint.identity || '*')
     const sender = await this.senders.map(identity.id, endpoint.sender || '*')
     const thread = await this.threads.map(sender.id, endpoint.thread || '*')
-
-    const usermap = await this.usermap.getBySenderId(tunnel.id, sender.id)
-    let userId = usermap?.userId
-    if (!userId) {
-      userId = (await this.users.create(clientId)).id
-      await this.usermap.create(tunnel.id, userId, sender.id)
-    }
-
-    const convmap = await this.convmap.getByThreadId(tunnel.id, thread.id)
-    let conversationId = convmap?.conversationId
-    if (!conversationId) {
-      conversationId = (await this.conversations.create(clientId, userId)).id
-      await this.convmap.create(tunnel.id, conversationId, thread.id)
-    }
+    const userId = await this.usermap.map(tunnel.id, sender.id, clientId)
+    const conversationId = await this.convmap.map(tunnel.id, thread.id, clientId, userId)
 
     return {
       tunnelId: tunnel.id,

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -33,8 +33,15 @@ export class MappingService extends Service {
     this.identities = new IdentityService(this.db, this.caching)
     this.senders = new SenderService(this.db, this.caching, this.batching)
     this.threads = new ThreadService(this.db, this.caching, this.batching, this.senders)
-    this.usermap = new UsermapService(this.db, this.caching, this.batching, this.users, this.senders)
-    this.convmap = new ConvmapService(this.db, this.caching, this.batching, this.conversations, this.threads)
+    this.usermap = new UsermapService(this.db, this.caching, this.batching, this.users, this.tunnels, this.senders)
+    this.convmap = new ConvmapService(
+      this.db,
+      this.caching,
+      this.batching,
+      this.conversations,
+      this.tunnels,
+      this.threads
+    )
     this.sandboxmap = new SandboxmapService(this.db, this.caching)
   }
 
@@ -53,8 +60,8 @@ export class MappingService extends Service {
     const identity = await this.identities.map(tunnel.id, endpoint.identity || '*')
     const sender = await this.senders.map(identity.id, endpoint.sender || '*')
     const thread = await this.threads.map(sender.id, endpoint.thread || '*')
-    const usermap = await this.usermap.map(tunnel.id, sender.id, clientId)
-    const convmap = await this.convmap.map(tunnel.id, thread.id, clientId, usermap.userId)
+    const usermap = await this.usermap.map(tunnel.id, sender.id)
+    const convmap = await this.convmap.map(tunnel.id, thread.id, usermap.userId)
 
     return {
       tunnelId: tunnel.id,

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -31,7 +31,7 @@ export class MappingService extends Service {
     super()
 
     this.tunnels = new TunnelService(this.db, this.caching, this.barriers)
-    this.identities = new IdentityService(this.db, this.caching)
+    this.identities = new IdentityService(this.db, this.caching, this.barriers)
     this.senders = new SenderService(this.db, this.caching, this.batching)
     this.threads = new ThreadService(this.db, this.caching, this.batching, this.senders)
     this.usermap = new UsermapService(

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -32,7 +32,7 @@ export class MappingService extends Service {
 
     this.tunnels = new TunnelService(this.db, this.caching, this.barriers)
     this.identities = new IdentityService(this.db, this.caching, this.barriers)
-    this.senders = new SenderService(this.db, this.caching, this.batching)
+    this.senders = new SenderService(this.db, this.caching, this.batching, this.barriers)
     this.threads = new ThreadService(this.db, this.caching, this.batching, this.senders)
     this.usermap = new UsermapService(
       this.db,

--- a/packages/server/src/mapping/usermap/service.ts
+++ b/packages/server/src/mapping/usermap/service.ts
@@ -9,6 +9,7 @@ import {
 } from '@botpress/messaging-engine'
 import { UserService } from '../../users/service'
 import { SenderService } from '../senders/service'
+import { TunnelService } from '../tunnels/service'
 import { UsermapTable } from './table'
 import { Usermap } from './types'
 
@@ -23,6 +24,7 @@ export class UsermapService extends Service {
     private caching: CachingService,
     private batching: BatchingService,
     private users: UserService,
+    private tunnels: TunnelService,
     private senders: SenderService
   ) {
     super()
@@ -78,15 +80,15 @@ export class UsermapService extends Service {
     }
   }
 
-  // TODO: remove clientId from param list
-  async map(tunnelId: uuid, senderId: uuid, clientId: uuid): Promise<Usermap> {
+  async map(tunnelId: uuid, senderId: uuid): Promise<Usermap> {
     const usermap = await this.getBySenderId(tunnelId, senderId)
     if (!usermap) {
       let promise = this.locks.get(tunnelId, senderId)
 
       if (!promise) {
         promise = new Promise(async (resolve) => {
-          const user = await this.users.create(clientId)
+          const tunnel = await this.tunnels.get(tunnelId)
+          const user = await this.users.create(tunnel!.clientId)
           const usermap = await this.create(tunnelId, user.id, senderId)
 
           resolve(usermap)

--- a/packages/server/src/mapping/usermap/service.ts
+++ b/packages/server/src/mapping/usermap/service.ts
@@ -76,6 +76,18 @@ export class UsermapService extends Service {
     }
   }
 
+  // TODO: remove clientId from param list
+  async map(tunnelId: uuid, senderId: uuid, clientId: uuid): Promise<uuid> {
+    const usermap = await this.getBySenderId(tunnelId, senderId)
+    let userId = usermap?.userId
+    if (!userId) {
+      userId = (await this.users.create(clientId)).id
+      await this.create(tunnelId, userId, senderId)
+    }
+
+    return userId
+  }
+
   private query() {
     return this.db.knex(this.table.id)
   }

--- a/packages/server/test/mapping.test.ts
+++ b/packages/server/test/mapping.test.ts
@@ -15,10 +15,19 @@ export interface Mapping {
   conversationId: uuid
 }
 
+const generateEndpoint = (args?: { identity?: string; sender?: string; thread?: string }) => {
+  return {
+    identity: args?.identity || crypto.randomBytes(20).toString('hex'),
+    sender: args?.sender || crypto.randomBytes(20).toString('hex'),
+    thread: args?.thread || crypto.randomBytes(20).toString('hex')
+  }
+}
+
 describe('Mapping', () => {
   let mapping: MappingService
   let clientId: uuid
   let channelId: uuid
+  let channelId2: uuid
   const state: { provider?: Provider; endpoint?: Endpoint; mapping?: Mapping } = {}
 
   beforeAll(async () => {
@@ -26,6 +35,7 @@ describe('Mapping', () => {
     mapping = app.mapping
     clientId = (await app.clients.create(undefined!, await app.clients.generateToken())).id
     channelId = app.channels.getByName('telegram').id
+    channelId2 = app.channels.getByName('twilio').id
   })
 
   afterAll(async () => {
@@ -37,12 +47,7 @@ describe('Mapping', () => {
   })
 
   test('Mapping an endpoint', async () => {
-    state.endpoint = {
-      identity: crypto.randomBytes(20).toString('hex'),
-      sender: crypto.randomBytes(20).toString('hex'),
-      thread: crypto.randomBytes(20).toString('hex')
-    }
-
+    state.endpoint = generateEndpoint()
     const map = await mapping.getMapping(clientId, channelId, state.endpoint)
 
     expect(map).toBeDefined()
@@ -62,18 +67,115 @@ describe('Mapping', () => {
     expect(map).toEqual(state.mapping)
   })
 
+  test('Mapping a completely different endpoint returns a completely different mapping', async () => {
+    const endpoint = generateEndpoint()
+    const map = await mapping.getMapping(clientId, channelId2, endpoint)
+
+    expect(map.tunnelId).not.toBe(state.mapping!.tunnelId)
+    expect(map.identityId).not.toBe(state.mapping!.identityId)
+    expect(map.senderId).not.toBe(state.mapping!.senderId)
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.userId).not.toBe(state.mapping!.userId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
+  test('Mapping an endpoint with the same channel returns only the same tunnel', async () => {
+    const endpoint = generateEndpoint()
+    const map = await mapping.getMapping(clientId, channelId, endpoint)
+
+    expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+
+    expect(map.identityId).not.toBe(state.mapping!.identityId)
+    expect(map.senderId).not.toBe(state.mapping!.senderId)
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.userId).not.toBe(state.mapping!.userId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
+  test('Mapping an endpoint with the same channel and identity returns only the same tunnel and identity', async () => {
+    const endpoint = generateEndpoint({ identity: state.endpoint!.identity })
+    const map = await mapping.getMapping(clientId, channelId, endpoint)
+
+    expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+    expect(map.identityId).toBe(state.mapping!.identityId)
+
+    expect(map.senderId).not.toBe(state.mapping!.senderId)
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.userId).not.toBe(state.mapping!.userId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
+  test('Mapping an endpoint with the same channel, identity and sender returns only the same tunnel, identity, senderId and userId', async () => {
+    const endpoint = generateEndpoint({ identity: state.endpoint!.identity, sender: state.endpoint!.sender })
+    const map = await mapping.getMapping(clientId, channelId, endpoint)
+
+    expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+    expect(map.identityId).toBe(state.mapping!.identityId)
+    expect(map.senderId).toBe(state.mapping!.senderId)
+    expect(map.userId).toBe(state.mapping!.userId)
+
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
+  test('Mapping an endpoint with only the same identity returns a completely different mapping', async () => {
+    const endpoint = generateEndpoint({ identity: state.endpoint!.identity })
+    const map = await mapping.getMapping(clientId, channelId2, endpoint)
+
+    expect(map.tunnelId).not.toBe(state.mapping!.tunnelId)
+    expect(map.identityId).not.toBe(state.mapping!.identityId)
+    expect(map.senderId).not.toBe(state.mapping!.senderId)
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.userId).not.toBe(state.mapping!.userId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
+  test('Mapping an endpoint with only the same channel and sender returns a completely different mapping', async () => {
+    const endpoint = generateEndpoint({ sender: state.endpoint!.sender })
+    const map = await mapping.getMapping(clientId, channelId, endpoint)
+
+    expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+
+    expect(map.identityId).not.toBe(state.mapping!.identityId)
+    expect(map.senderId).not.toBe(state.mapping!.senderId)
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.userId).not.toBe(state.mapping!.userId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
+  test('Mapping an endpoint with only the same channel and thread returns a completely different mapping', async () => {
+    const endpoint = generateEndpoint({ thread: state.endpoint!.thread })
+    const map = await mapping.getMapping(clientId, channelId, endpoint)
+
+    expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+
+    expect(map.identityId).not.toBe(state.mapping!.identityId)
+    expect(map.senderId).not.toBe(state.mapping!.senderId)
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.userId).not.toBe(state.mapping!.userId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
+  test('Mapping an endpoint with the same channel, identity and thread does not return the same senderId and threadId', async () => {
+    const endpoint = generateEndpoint({ identity: state.endpoint!.identity, thread: state.endpoint!.thread })
+    const map = await mapping.getMapping(clientId, channelId, endpoint)
+
+    expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+    expect(map.identityId).toBe(state.mapping!.identityId)
+
+    expect(map.senderId).not.toBe(state.mapping!.senderId)
+    expect(map.threadId).not.toBe(state.mapping!.threadId)
+    expect(map.userId).not.toBe(state.mapping!.userId)
+    expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+  })
+
   test('Get endpoint from threadId', async () => {
     const endpoint = await mapping.getEndpoint(state.mapping!.threadId!)
     expect(endpoint).toEqual(state.endpoint)
   })
 
   test('Mapping repeateldy does not produce race conditions', async () => {
-    const endpoint = {
-      identity: crypto.randomBytes(20).toString('hex'),
-      sender: crypto.randomBytes(20).toString('hex'),
-      thread: crypto.randomBytes(20).toString('hex')
-    }
-
+    const endpoint = generateEndpoint()
     const promises: Promise<Mapping>[] = []
 
     for (let i = 0; i < 100; i++) {

--- a/packages/server/test/mapping.test.ts
+++ b/packages/server/test/mapping.test.ts
@@ -1,0 +1,52 @@
+import { uuid } from '@botpress/messaging-base'
+import { validate as validateUuid } from 'uuid'
+import { MappingService } from '../src/mapping/service'
+import { Provider } from '../src/providers/types'
+import { setupApp, app } from './util/app'
+
+export interface Mapping {
+  tunnelId: uuid
+  identityId: uuid
+  senderId: uuid
+  threadId: uuid
+  userId: uuid
+  conversationId: uuid
+}
+
+describe('Mapping', () => {
+  let mapping: MappingService
+  let clientId: uuid
+  let channelId: uuid
+  const state: { provider?: Provider } = {}
+
+  beforeAll(async () => {
+    await setupApp()
+    mapping = app.mapping
+    clientId = (await app.clients.create(undefined!, await app.clients.generateToken())).id
+    channelId = app.channels.getByName('telegram').id
+  })
+
+  afterAll(async () => {
+    await app.destroy()
+  })
+
+  beforeEach(async () => {
+    app.caching.resetAll()
+  })
+
+  test('Mapping an endpoint', async () => {
+    const map = await mapping.getMapping(clientId, channelId, {
+      identity: 'botname',
+      sender: 'bob',
+      thread: '1234'
+    })
+
+    expect(map).toBeDefined()
+    expect(validateUuid(map.tunnelId)).toBeTruthy()
+    expect(validateUuid(map.identityId)).toBeTruthy()
+    expect(validateUuid(map.senderId)).toBeTruthy()
+    expect(validateUuid(map.threadId)).toBeTruthy()
+    expect(validateUuid(map.userId)).toBeTruthy()
+    expect(validateUuid(map.conversationId)).toBeTruthy()
+  })
+})

--- a/packages/server/test/mapping.test.ts
+++ b/packages/server/test/mapping.test.ts
@@ -61,4 +61,30 @@ describe('Mapping', () => {
 
     expect(map).toEqual(state.mapping)
   })
+
+  test('Get endpoint from threadId', async () => {
+    const endpoint = await mapping.getEndpoint(state.mapping!.threadId!)
+    expect(endpoint).toEqual(state.endpoint)
+  })
+
+  test('Mapping repeateldy does not produce race conditions', async () => {
+    const endpoint = {
+      identity: crypto.randomBytes(20).toString('hex'),
+      sender: crypto.randomBytes(20).toString('hex'),
+      thread: crypto.randomBytes(20).toString('hex')
+    }
+
+    const promises: Promise<Mapping>[] = []
+
+    for (let i = 0; i < 100; i++) {
+      promises.push(mapping.getMapping(clientId, channelId, endpoint))
+    }
+
+    const mappings = await Promise.all(promises)
+
+    // they should have all mapped to the same thing
+    for (const mapping of mappings) {
+      expect(mapping).toEqual(mappings[0])
+    }
+  })
 })

--- a/packages/server/test/tsconfig.json
+++ b/packages/server/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.packages.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["../test/**/*", "../src/**/*"]
+}


### PR DESCRIPTION
It's sometime possible that sometimes the server checks if a mapping exists, and then creates it if it doesn't. If this is done fast enough, it's possible that the check to see if the mapping exists returns false more than once, and the process of creating the mapping starts multiple times. The constraints in the db will prevent more than once request from succeeding, meaning that exceptions will be thrown.

This PR fixes this problem

Closes DEV-1618