### PR TITLE
fix(redis): fix master failure crashing the server

### DIFF
--- a/packages/engine/src/distributed/redis/subservice.ts
+++ b/packages/engine/src/distributed/redis/subservice.ts
@@ -77,14 +77,12 @@ export class RedisSubservice implements DistributedSubservice {
     }
 
     const retryStrategy = (times: number) => {
-      if (times > 10) {
-        throw new Error('Unable to connect to the Redis cluster after multiple attempts')
-      }
       return Math.min(times * 200, 5000)
     }
 
     const redisOptions: RedisOptions = {
-      retryStrategy
+      retryStrategy,
+      sentinelRetryStrategy: retryStrategy
     }
 
     if (_.isArray(connection)) {

--- a/packages/engine/src/distributed/redis/subservice.ts
+++ b/packages/engine/src/distributed/redis/subservice.ts
@@ -20,6 +20,7 @@ export class RedisSubservice implements DistributedSubservice {
   private callbacks: { [channel: string]: (message: any, channel: string) => Promise<void> } = {}
   private pings!: PingPong
   private scope!: string
+  private destroyed: boolean = false
 
   async setup() {
     this.logger.info(`Id is ${clc.bold(RedisSubservice.nodeId)}`)
@@ -77,6 +78,9 @@ export class RedisSubservice implements DistributedSubservice {
     }
 
     const retryStrategy = (times: number) => {
+      if (this.destroyed) {
+        throw new Error('Unable to connect to the Redis cluster after multiple attempts')
+      }
       return Math.min(times * 200, 5000)
     }
 
@@ -98,6 +102,8 @@ export class RedisSubservice implements DistributedSubservice {
   }
 
   async destroy() {
+    this.destroyed = true
+
     const now = new Date()
 
     for (const lock of Object.values(this.locks || {})) {


### PR DESCRIPTION
There was a problem when using redis with sentinel, master and slaves where switching a master could make the server crash. The server was set to throw an exception is an attempt to connect failed more than 10 times. I removed this limit so now the server can retry to connect to redis indefinitely.

Closes DEV-2002