### PR TITLE
chore(ci): use botpress shared actions v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@master
+        uses: botpress/gh-actions/get_release_details@v1
 
       - name: Fix Change Log
         id: changelog


### PR DESCRIPTION
This PR pins the version of the action(s) we use from https://github.com/botpress/gh-actions to `v1`