### PR TITLE
fix(sync): add lock for provider name

### DIFF
--- a/packages/server/src/migrations/0.1.20-fix-client-schema.ts
+++ b/packages/server/src/migrations/0.1.20-fix-client-schema.ts
@@ -1,0 +1,25 @@
+import { Migration } from '@botpress/messaging-engine'
+
+export class FixClientSchemaMigration extends Migration {
+  meta = {
+    name: FixClientSchemaMigration.name,
+    description: 'Fixes broken msg_clients table schema',
+    version: '0.1.20'
+  }
+
+  async valid() {
+    return this.trx.schema.hasTable('msg_clients')
+  }
+
+  async applied() {
+    return false
+  }
+
+  async up() {
+    return this.trx.schema.alterTable('msg_clients', (table) => {
+      table.uuid('providerId').nullable().alter()
+    })
+  }
+
+  async down() {}
+}

--- a/packages/server/src/migrations/index.ts
+++ b/packages/server/src/migrations/index.ts
@@ -1,4 +1,5 @@
 import { Migration } from '@botpress/messaging-engine'
 import { StatusMigration } from './0.1.19-status'
+import { FixClientSchemaMigration } from './0.1.20-fix-client-schema'
 
-export const Migrations: { new (): Migration }[] = [StatusMigration]
+export const Migrations: { new (): Migration }[] = [StatusMigration, FixClientSchemaMigration]

--- a/packages/server/src/sync/service.ts
+++ b/packages/server/src/sync/service.ts
@@ -65,7 +65,9 @@ export class SyncService extends Service {
       result = { id: client.id, token: client.token || req.token!, webhooks }
     }
 
-    if (req.id) {
+    if (req.name) {
+      await this.distributed.using(`lock_dyn_sync_provider::${req.name}`, lockedTask)
+    } else if (req.id) {
       await this.distributed.using(`lock_dyn_sync_client::${req.id}`, lockedTask)
     } else {
       await lockedTask()


### PR DESCRIPTION
Fixes a problem in sync calls when messaging is spinned where multiple calls made with the same botId would not be locked. Related https://github.com/botpress/botpress/pull/5760

Closes DEV-2189