### PR TITLE
chore(repo): add fetch functions

### DIFF
--- a/packages/channels/src/messenger/senders/common.ts
+++ b/packages/channels/src/messenger/senders/common.ts
@@ -4,7 +4,7 @@ import { MessengerContext } from '../context'
 export class MessengerCommonSender extends CommonSender {
   async send(context: MessengerContext) {
     for (const message of context.messages) {
-      await context.state.client.sendMessage(context.sender!, message)
+      await context.state.client.sendMessage(context.sender, message)
     }
   }
 }

--- a/packages/channels/src/messenger/senders/typing.ts
+++ b/packages/channels/src/messenger/senders/typing.ts
@@ -3,10 +3,10 @@ import { MessengerContext } from '../context'
 
 export class MessengerTypingSender extends TypingSender {
   async sendIndicator(context: MessengerContext) {
-    await context.state.client.sendAction(context.sender!, 'typing_on')
+    await context.state.client.sendAction(context.sender, 'typing_on')
   }
 
   async stopIndicator(context: MessengerContext) {
-    await context.state.client.sendAction(context.sender!, 'typing_off')
+    await context.state.client.sendAction(context.sender, 'typing_off')
   }
 }

--- a/packages/channels/src/slack/senders/common.ts
+++ b/packages/channels/src/slack/senders/common.ts
@@ -4,7 +4,7 @@ import { SlackContext } from '../context'
 export class SlackCommonSender extends CommonSender {
   async send(context: SlackContext) {
     await context.state.client.chat.postMessage({
-      channel: context.thread!,
+      channel: context.thread,
       text: <any>undefined,
       ...context.message
     })

--- a/packages/channels/src/telegram/senders/common.ts
+++ b/packages/channels/src/telegram/senders/common.ts
@@ -5,7 +5,7 @@ import { TelegramContext } from '../context'
 export class TelegramCommonSender extends CommonSender {
   async send(context: TelegramContext) {
     const telegram = context.state.telegraf.telegram
-    const chatId = context.thread!
+    const chatId = context.thread
 
     for (const message of context.messages) {
       if (message.action) {

--- a/packages/channels/src/telegram/senders/typing.ts
+++ b/packages/channels/src/telegram/senders/typing.ts
@@ -3,6 +3,6 @@ import { TelegramContext } from '../context'
 
 export class TelegramTypingSender extends TypingSender {
   async sendIndicator(context: TelegramContext) {
-    await context.state.telegraf.telegram.sendChatAction(context.thread!, 'typing')
+    await context.state.telegraf.telegram.sendChatAction(context.thread, 'typing')
   }
 }

--- a/packages/channels/src/twilio/renderers/carousel.ts
+++ b/packages/channels/src/twilio/renderers/carousel.ts
@@ -40,8 +40,8 @@ export class TwilioCarouselRenderer extends CarouselRenderer {
     context.channel.messages.push(<any>{ body, mediaUrl: card.image })
     context.channel.prepareIndexResponse(
       context.channel.scope,
-      context.channel.identity!,
-      context.channel.sender!,
+      context.channel.identity,
+      context.channel.sender,
       context.options
     )
   }

--- a/packages/channels/src/twilio/renderers/choices.ts
+++ b/packages/channels/src/twilio/renderers/choices.ts
@@ -17,8 +17,8 @@ export class TwilioChoicesRenderer extends ChoicesRenderer {
 
     context.prepareIndexResponse(
       context.scope,
-      context.identity!,
-      context.sender!,
+      context.identity,
+      context.sender,
       payload.choices.map((x: ChoiceOption) => ({ ...x, type: IndexChoiceType.QuickReply }))
     )
   }

--- a/packages/channels/src/twilio/senders/common.ts
+++ b/packages/channels/src/twilio/senders/common.ts
@@ -7,7 +7,7 @@ export class TwilioCommonSender extends CommonSender {
       await context.state.twilio.messages.create({
         ...message,
         from: context.identity,
-        to: context.sender!
+        to: context.sender
       })
     }
   }

--- a/packages/channels/src/vonage/renderers/choices.ts
+++ b/packages/channels/src/vonage/renderers/choices.ts
@@ -13,8 +13,8 @@ export class VonageChoicesRenderer extends ChoicesRenderer {
 
     context.prepareIndexResponse(
       context.scope,
-      context.identity!,
-      context.sender!,
+      context.identity,
+      context.sender,
       payload.choices.map((x) => ({ type: IndexChoiceType.QuickReply, ...x }))
     )
   }

--- a/packages/channels/src/vonage/senders/common.ts
+++ b/packages/channels/src/vonage/senders/common.ts
@@ -6,10 +6,10 @@ export class VonageCommonSender extends CommonSender {
     for (const message of context.messages) {
       await new Promise((resolve) => {
         context.state.vonage.channel.send(
-          { type: 'whatsapp', number: context.sender! },
+          { type: 'whatsapp', number: context.sender },
           {
             type: 'whatsapp',
-            number: context.identity!
+            number: context.identity
           },
           message,
           (err, data) => {

--- a/packages/chat/src/conversation/system.ts
+++ b/packages/chat/src/conversation/system.ts
@@ -31,7 +31,7 @@ export class WebchatConversation extends WebchatSystem {
 
     this.storage.set(STORAGE_ID, conversation.id)
 
-    await this.set(conversation!)
+    await this.set(conversation)
   }
 
   get() {

--- a/packages/server/src/channels/api.ts
+++ b/packages/server/src/channels/api.ts
@@ -49,11 +49,11 @@ export class ChannelApi {
 
   async map(channel: Channel, scope: string, endpoint: Endpoint, content: any): Promise<Mapping | undefined> {
     const provider = await this.app.providers.getByName(scope)
-    const conduit = await this.app.conduits.getByProviderAndChannel(provider!.id, channel.meta.id)
+    const conduit = await this.app.conduits.getByProviderAndChannel(provider.id, channel.meta.id)
 
-    const clientId = provider!.sandbox
+    const clientId = provider.sandbox
       ? await this.app.instances.sandbox.getClientId(conduit!.id, endpoint, content)
-      : (await this.app.clients.getByProviderId(provider!.id))!.id
+      : (await this.app.clients.getByProviderId(provider.id))!.id
 
     if (!clientId) {
       return undefined

--- a/packages/server/src/channels/api.ts
+++ b/packages/server/src/channels/api.ts
@@ -52,7 +52,7 @@ export class ChannelApi {
     const conduit = await this.app.conduits.getByProviderAndChannel(provider.id, channel.meta.id)
 
     const clientId = provider.sandbox
-      ? await this.app.instances.sandbox.getClientId(conduit!.id, endpoint, content)
+      ? await this.app.instances.sandbox.getClientId(conduit.id, endpoint, content)
       : (await this.app.clients.getByProviderId(provider.id)).id
 
     if (!clientId) {

--- a/packages/server/src/channels/api.ts
+++ b/packages/server/src/channels/api.ts
@@ -53,7 +53,7 @@ export class ChannelApi {
 
     const clientId = provider.sandbox
       ? await this.app.instances.sandbox.getClientId(conduit!.id, endpoint, content)
-      : (await this.app.clients.getByProviderId(provider.id))!.id
+      : (await this.app.clients.getByProviderId(provider.id)).id
 
     if (!clientId) {
       return undefined

--- a/packages/server/src/clients/service.ts
+++ b/packages/server/src/clients/service.ts
@@ -95,7 +95,7 @@ export class ClientService extends Service {
       }
     }
 
-    if (await this.cryptoService.compareHash(client.token!, token)) {
+    if (await this.cryptoService.compareHash(client.token, token)) {
       this.cacheTokens.set(id, token)
       return client
     } else {

--- a/packages/server/src/clients/types.ts
+++ b/packages/server/src/clients/types.ts
@@ -3,5 +3,5 @@ import { uuid } from '@botpress/messaging-base'
 export interface Client {
   id: uuid
   providerId: uuid
-  token?: string
+  token: string
 }

--- a/packages/server/src/conduits/service.ts
+++ b/packages/server/src/conduits/service.ts
@@ -65,7 +65,7 @@ export class ConduitService extends Service {
   }
 
   async delete(id: uuid) {
-    const conduit = (await this.get(id))!
+    const conduit = await this.get(id)
     this.cacheById.del(id, true)
     this.cacheByProviderAndChannel.del(conduit.providerId, conduit.channelId, true)
 
@@ -75,7 +75,7 @@ export class ConduitService extends Service {
   }
 
   async updateConfig(id: uuid, config: any) {
-    const conduit = (await this.get(id))!
+    const conduit = await this.get(id)
     const channel = this.channelService.getById(conduit.channelId)
     const validConfig = await channel.meta.schema.validateAsync(config)
 
@@ -89,7 +89,7 @@ export class ConduitService extends Service {
     await this.emitter.emit(ConduitEvents.Updated, id)
   }
 
-  async get(id: uuid): Promise<Conduit | undefined> {
+  async fetch(id: uuid): Promise<Conduit | undefined> {
     const cached = this.cacheById.get(id)
     if (cached) {
       return cached
@@ -104,6 +104,14 @@ export class ConduitService extends Service {
     }
 
     return undefined
+  }
+
+  async get(id: uuid): Promise<Conduit> {
+    const val = await this.fetch(id)
+    if (!val) {
+      throw new Error(`Conduit ${id} not found`)
+    }
+    return val
   }
 
   async getByProviderAndChannel(providerId: uuid, channelId: uuid) {

--- a/packages/server/src/conduits/service.ts
+++ b/packages/server/src/conduits/service.ts
@@ -114,7 +114,7 @@ export class ConduitService extends Service {
     return val
   }
 
-  async getByProviderAndChannel(providerId: uuid, channelId: uuid) {
+  async fetchByProviderAndChannel(providerId: uuid, channelId: uuid) {
     const cached = this.cacheByProviderAndChannel.get(providerId, channelId)
     if (cached) {
       return cached
@@ -129,6 +129,14 @@ export class ConduitService extends Service {
     }
 
     return undefined
+  }
+
+  async getByProviderAndChannel(providerId: uuid, channelId: uuid) {
+    const val = await this.fetchByProviderAndChannel(providerId, channelId)
+    if (!val) {
+      throw Error(`Conduit with provider ${providerId} and channel ${channelId} not found`)
+    }
+    return val
   }
 
   async listByProvider(providerId: uuid): Promise<Conduit[]> {

--- a/packages/server/src/conversations/api.ts
+++ b/packages/server/src/conversations/api.ts
@@ -22,7 +22,7 @@ export class ConversationApi {
   async create(req: ClientApiRequest, res: Response) {
     const userId = req.body.userId as uuid
 
-    const user = await this.users.get(userId)
+    const user = await this.users.fetch(userId)
     if (!user || user!.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -46,7 +46,7 @@ export class ConversationApi {
     const userId = req.params.userId as uuid
     const limit = +(req.query.limit || DEFAULT_LIMIT)
 
-    const user = await this.users.get(userId)
+    const user = await this.users.fetch(userId)
     if (!user || user.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -58,7 +58,7 @@ export class ConversationApi {
   async recent(req: ClientApiRequest, res: Response) {
     const userId = req.params.userId as uuid
 
-    const user = await this.users.get(userId)
+    const user = await this.users.fetch(userId)
     if (!user || user.clientId !== req.client.id) {
       return res.sendStatus(404)
     }

--- a/packages/server/src/conversations/api.ts
+++ b/packages/server/src/conversations/api.ts
@@ -34,7 +34,7 @@ export class ConversationApi {
   async get(req: ClientApiRequest, res: Response) {
     const id = req.params.id as uuid
 
-    const conversation = await this.conversations.get(id)
+    const conversation = await this.conversations.fetch(id)
     if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -63,7 +63,7 @@ export class ConversationApi {
       return res.sendStatus(404)
     }
 
-    let conversation = await this.conversations.getMostRecent(req.client.id, userId)
+    let conversation = await this.conversations.fetchMostRecent(req.client.id, userId)
     if (!conversation) {
       conversation = await this.conversations.create(req.client.id, userId)
     }

--- a/packages/server/src/conversations/api.ts
+++ b/packages/server/src/conversations/api.ts
@@ -23,7 +23,7 @@ export class ConversationApi {
     const userId = req.body.userId as uuid
 
     const user = await this.users.fetch(userId)
-    if (!user || user!.clientId !== req.client.id) {
+    if (!user || user.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
 

--- a/packages/server/src/conversations/service.ts
+++ b/packages/server/src/conversations/service.ts
@@ -78,12 +78,12 @@ export class ConversationService extends Service {
     const conversation = await this.get(id)
 
     this.cache.del(id, true)
-    this.cacheMostRecent.del(conversation!.userId, true)
+    this.cacheMostRecent.del(conversation.userId, true)
 
     return this.query().where({ id }).del()
   }
 
-  public async get(id: uuid): Promise<Conversation | undefined> {
+  public async fetch(id: uuid): Promise<Conversation | undefined> {
     const cached = this.cache.get(id)
     if (cached) {
       return cached
@@ -103,7 +103,15 @@ export class ConversationService extends Service {
     return undefined
   }
 
-  public async getMostRecent(clientId: uuid, userId: uuid): Promise<Conversation | undefined> {
+  public async get(id: uuid): Promise<Conversation> {
+    const val = await this.fetch(id)
+    if (!val) {
+      throw new Error(`Conversation ${id} not found`)
+    }
+    return val
+  }
+
+  public async fetchMostRecent(clientId: uuid, userId: uuid): Promise<Conversation | undefined> {
     // TODO: need to figure out batching for this
 
     const cached = this.cacheMostRecent.get(userId)
@@ -179,7 +187,7 @@ export class ConversationService extends Service {
 
     if (currentMostRecent?.id !== conversationId) {
       const conversation = await this.get(conversationId)
-      this.cacheMostRecent.set(userId, conversation!)
+      this.cacheMostRecent.set(userId, conversation)
     }
   }
 

--- a/packages/server/src/conversations/socket.ts
+++ b/packages/server/src/conversations/socket.ts
@@ -35,7 +35,7 @@ export class ConversationSocket {
     const { limit } = socket.data
 
     const user = await this.users.get(socket.userId)
-    const conversations = await this.conversations.listByUserId(user!.clientId, socket.userId, +limit)
+    const conversations = await this.conversations.listByUserId(user.clientId, socket.userId, +limit)
 
     socket.reply(conversations)
   }

--- a/packages/server/src/conversations/socket.ts
+++ b/packages/server/src/conversations/socket.ts
@@ -15,7 +15,7 @@ export class ConversationSocket {
 
   async create(socket: SocketRequest) {
     const user = await this.users.get(socket.userId)
-    const conversation = await this.conversations.create(user!.clientId, user!.id)
+    const conversation = await this.conversations.create(user.clientId, user.id)
 
     socket.reply(conversation)
   }

--- a/packages/server/src/conversations/socket.ts
+++ b/packages/server/src/conversations/socket.ts
@@ -22,7 +22,7 @@ export class ConversationSocket {
 
   async get(socket: SocketRequest) {
     const { id } = socket.data
-    const conversation = await this.conversations.get(id)
+    const conversation = await this.conversations.fetch(id)
 
     if (!conversation || conversation.userId !== socket.userId) {
       return socket.reply(undefined)
@@ -42,7 +42,7 @@ export class ConversationSocket {
 
   async delete(socket: SocketRequest) {
     const { id } = socket.data
-    const conversation = await this.conversations.get(id)
+    const conversation = await this.conversations.fetch(id)
 
     if (!conversation) {
       return socket.reply(false)

--- a/packages/server/src/conversations/stream.ts
+++ b/packages/server/src/conversations/stream.ts
@@ -31,8 +31,8 @@ export class ConversationStream {
     const conversation = await this.conversations.get(conversationId)
     await this.streamer.stream(
       'conversation.started',
-      { conversationId, userId: conversation!.userId, channel: await this.getChannel(conversationId) },
-      conversation!.clientId
+      { conversationId, userId: conversation.userId, channel: await this.getChannel(conversationId) },
+      conversation.clientId
     )
   }
 

--- a/packages/server/src/converse/service.ts
+++ b/packages/server/src/converse/service.ts
@@ -58,7 +58,9 @@ export class ConverseService extends Service {
     const childCollectors = collectors.filter((x) => x.incomingId === incomingId)
 
     for (const collector of childCollectors) {
-      clearTimeout(collector.timeout!)
+      if (collector.timeout) {
+        clearTimeout(collector.timeout)
+      }
       this.removeCollector(collector)
       this.resolveCollect(collector)
     }
@@ -122,7 +124,7 @@ export class ConverseService extends Service {
   private removeCollector(collector: Collector) {
     const { conversationId } = collector
 
-    const collectors = this.collectors.get(conversationId)!
+    const collectors = this.collectors.get(conversationId) || []
     const index = collectors.indexOf(collector)
     if (index >= 0) {
       collectors.splice(index, 1)

--- a/packages/server/src/health/listener.ts
+++ b/packages/server/src/health/listener.ts
@@ -58,7 +58,7 @@ export class HealthListener {
 
   private async handleInstanceDestroyed(conduitId: uuid) {
     // It's possible that this gets called by the cleared cached after the conduit was deleted from the db
-    if (await this.conduitService.get(conduitId)) {
+    if (await this.conduitService.fetch(conduitId)) {
       try {
         await this.healthService.register(conduitId, HealthEventType.Sleep)
       } catch {

--- a/packages/server/src/health/service.ts
+++ b/packages/server/src/health/service.ts
@@ -52,7 +52,7 @@ export class HealthService extends Service {
     }
 
     const conduit = await this.conduitService.get(conduitId)
-    const client = await this.clientService.getByProviderId(conduit.providerId)
+    const client = await this.clientService.fetchByProviderId(conduit.providerId)
     if (client) {
       this.cache.del(client.id, true)
     }
@@ -68,7 +68,7 @@ export class HealthService extends Service {
     }
 
     const client = await this.clientService.getById(clientId)
-    const conduits = await this.conduitService.listByProvider(client!.providerId)
+    const conduits = await this.conduitService.listByProvider(client.providerId)
 
     const report: HealthReport = { channels: {} }
 

--- a/packages/server/src/health/service.ts
+++ b/packages/server/src/health/service.ts
@@ -52,7 +52,7 @@ export class HealthService extends Service {
     }
 
     const conduit = await this.conduitService.get(conduitId)
-    const client = await this.clientService.getByProviderId(conduit!.providerId)
+    const client = await this.clientService.getByProviderId(conduit.providerId)
     if (client) {
       this.cache.del(client.id, true)
     }

--- a/packages/server/src/health/stream.ts
+++ b/packages/server/src/health/stream.ts
@@ -20,7 +20,7 @@ export class HealthStream {
 
   private async handleHealthRegisted({ event }: HealthCreatedEvent) {
     const conduit = await this.conduits.get(event.conduitId)
-    const client = await this.clients.getByProviderId(conduit.providerId)
+    const client = await this.clients.fetchByProviderId(conduit.providerId)
     if (!client) {
       return
     }

--- a/packages/server/src/health/stream.ts
+++ b/packages/server/src/health/stream.ts
@@ -20,12 +20,12 @@ export class HealthStream {
 
   private async handleHealthRegisted({ event }: HealthCreatedEvent) {
     const conduit = await this.conduits.get(event.conduitId)
-    const client = await this.clients.getByProviderId(conduit!.providerId)
+    const client = await this.clients.getByProviderId(conduit.providerId)
     if (!client) {
       return
     }
 
-    const channel = this.channels.getById(conduit!.channelId)
+    const channel = this.channels.getById(conduit.channelId)
     await this.streamer.stream(
       'health.new',
       { channel: channel.meta.name, event: { ...this.health.makeReadable(event) } },

--- a/packages/server/src/instances/invalidator.ts
+++ b/packages/server/src/instances/invalidator.ts
@@ -33,7 +33,7 @@ export class InstanceInvalidator {
   }
 
   private async onConduitCreated(conduitId: uuid) {
-    const conduit = (await this.conduits.get(conduitId))!
+    const conduit = await this.conduits.get(conduitId)
     const channel = this.channels.getById(conduit.channelId)
 
     if (channel.meta.initiable) {
@@ -54,7 +54,7 @@ export class InstanceInvalidator {
     await this.status.updateInitializedOn(conduitId, undefined)
     await this.status.clearErrors(conduitId)
 
-    const conduit = (await this.conduits.get(conduitId))!
+    const conduit = await this.conduits.get(conduitId)
     const channel = this.channels.getById(conduit.channelId)
 
     if (channel.meta.initiable) {

--- a/packages/server/src/instances/invalidator.ts
+++ b/packages/server/src/instances/invalidator.ts
@@ -67,7 +67,7 @@ export class InstanceInvalidator {
   }
 
   private async onClientUpdated({ clientId, oldClient }: ClientUpdatedEvent) {
-    const client = (await this.clients.getById(clientId))!
+    const client = await this.clients.getById(clientId)
 
     if (client.providerId === oldClient.providerId) {
       return

--- a/packages/server/src/instances/invalidator.ts
+++ b/packages/server/src/instances/invalidator.ts
@@ -73,7 +73,7 @@ export class InstanceInvalidator {
       return
     }
 
-    const oldProvider = await this.providers.getById(oldClient.providerId)
+    const oldProvider = await this.providers.fetchById(oldClient.providerId)
     if (!oldProvider || oldProvider?.sandbox) {
       return
     }

--- a/packages/server/src/instances/monitoring.ts
+++ b/packages/server/src/instances/monitoring.ts
@@ -67,7 +67,7 @@ export class InstanceMonitoring {
 
       const conduits = await this.conduits.listByChannel(channel.meta.id)
       for (const conduit of conduits) {
-        const failures = (await this.status.get(conduit.id))?.numberOfErrors || 0
+        const failures = (await this.status.fetch(conduit.id))?.numberOfErrors || 0
         if (failures >= MAX_ALLOWED_FAILURES) {
           continue
         }

--- a/packages/server/src/instances/queue.ts
+++ b/packages/server/src/instances/queue.ts
@@ -31,12 +31,19 @@ export class LinkedQueue<T> {
   }
 
   public peek(): T {
-    return this.head!.value
+    if (!this.head) {
+      throw Error('Queue is empty')
+    }
+
+    return this.head.value
   }
 
   public dequeue(): T {
-    const link = this.head!
+    if (!this.head) {
+      throw Error('Queue is empty')
+    }
 
+    const link = this.head
     this.head = link.next
 
     if (this.tail === link) {

--- a/packages/server/src/instances/sandbox.ts
+++ b/packages/server/src/instances/sandbox.ts
@@ -46,7 +46,7 @@ export class InstanceSandbox {
   async tryJoinWithPassphrase(conduitId: uuid, endpoint: Endpoint, passphrase: string) {
     this.logger.info('Attempting to join sandbox with passphrase', passphrase)
 
-    const client = uuidValidate(passphrase) ? await this.clients.getById(passphrase) : undefined
+    const client = uuidValidate(passphrase) ? await this.clients.fetchById(passphrase) : undefined
 
     if (client) {
       this.logger.info('Joined sandbox!', client.id)

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -185,7 +185,7 @@ export class InstanceService extends Service {
 
   private async handleMessageCreated({ message, source }: MessageCreatedEvent) {
     const conversation = await this.conversationService.get(message.conversationId)
-    const client = await this.clientService.getById(conversation!.clientId)
+    const client = await this.clientService.getById(conversation.clientId)
     const convmaps = await this.mappingService.convmap.listByConversationId(message.conversationId)
 
     // small optimization. If the message comes from a channel, and we are only linked to one channel,

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -86,7 +86,7 @@ export class InstanceService extends Service {
       channel.autoStart(async (providerName) => {
         const provider = await this.providerService.getByName(providerName)
         const conduit = await this.conduitService.getByProviderAndChannel(provider.id, channel.meta.id)
-        return conduit!.config
+        return conduit.config
       })
     }
   }
@@ -99,7 +99,7 @@ export class InstanceService extends Service {
         const provider = await this.providerService.getByName(scope)
         const conduit = await this.conduitService.getByProviderAndChannel(provider.id, channel.meta.id)
 
-        await this.stop(conduit!.id)
+        await this.stop(conduit.id)
       }
     }
   }
@@ -199,7 +199,7 @@ export class InstanceService extends Service {
       const tunnel = await this.mappingService.tunnels.get(tunnelId)
 
       if (!source?.endpoint || !this.endpointEqual(source.endpoint, endpoint)) {
-        const conduit = await this.conduitService.getByProviderAndChannel(client.providerId, tunnel!.channelId)
+        const conduit = await this.conduitService.fetchByProviderAndChannel(client.providerId, tunnel!.channelId)
         if (!conduit) {
           return
         }

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -111,7 +111,7 @@ export class InstanceService extends Service {
   async initialize(conduitId: uuid) {
     await this.start(conduitId)
 
-    const conduit = (await this.conduitService.get(conduitId))!
+    const conduit = await this.conduitService.get(conduitId)
     const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 
@@ -131,7 +131,7 @@ export class InstanceService extends Service {
   }
 
   async start(conduitId: uuid) {
-    const conduit = (await this.conduitService.get(conduitId))!
+    const conduit = await this.conduitService.get(conduitId)
     const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 
@@ -157,7 +157,7 @@ export class InstanceService extends Service {
   }
 
   async sendToEndpoint(conduitId: uuid, endpoint: Endpoint, content: any) {
-    const conduit = (await this.conduitService.get(conduitId))!
+    const conduit = await this.conduitService.get(conduitId)
     const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 
@@ -165,7 +165,7 @@ export class InstanceService extends Service {
   }
 
   private async handleDispatchStop(conduitId: uuid) {
-    const conduit = (await this.conduitService.get(conduitId))!
+    const conduit = await this.conduitService.get(conduitId)
     const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -199,7 +199,7 @@ export class InstanceService extends Service {
       const tunnel = await this.mappingService.tunnels.get(tunnelId)
 
       if (!source?.endpoint || !this.endpointEqual(source.endpoint, endpoint)) {
-        const conduit = await this.conduitService.getByProviderAndChannel(client!.providerId, tunnel!.channelId)
+        const conduit = await this.conduitService.getByProviderAndChannel(client.providerId, tunnel!.channelId)
         if (!conduit) {
           return
         }

--- a/packages/server/src/instances/service.ts
+++ b/packages/server/src/instances/service.ts
@@ -85,7 +85,7 @@ export class InstanceService extends Service {
     for (const channel of this.channelService.list()) {
       channel.autoStart(async (providerName) => {
         const provider = await this.providerService.getByName(providerName)
-        const conduit = await this.conduitService.getByProviderAndChannel(provider!.id, channel.meta.id)
+        const conduit = await this.conduitService.getByProviderAndChannel(provider.id, channel.meta.id)
         return conduit!.config
       })
     }
@@ -97,7 +97,7 @@ export class InstanceService extends Service {
     for (const channel of this.channelService.list()) {
       for (const scope of channel.scopes) {
         const provider = await this.providerService.getByName(scope)
-        const conduit = await this.conduitService.getByProviderAndChannel(provider!.id, channel.meta.id)
+        const conduit = await this.conduitService.getByProviderAndChannel(provider.id, channel.meta.id)
 
         await this.stop(conduit!.id)
       }
@@ -112,7 +112,7 @@ export class InstanceService extends Service {
     await this.start(conduitId)
 
     const conduit = (await this.conduitService.get(conduitId))!
-    const provider = (await this.providerService.getById(conduit.providerId))!
+    const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 
     try {
@@ -132,7 +132,7 @@ export class InstanceService extends Service {
 
   async start(conduitId: uuid) {
     const conduit = (await this.conduitService.get(conduitId))!
-    const provider = (await this.providerService.getById(conduit.providerId))!
+    const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 
     if (channel.has(provider.name)) {
@@ -158,7 +158,7 @@ export class InstanceService extends Service {
 
   async sendToEndpoint(conduitId: uuid, endpoint: Endpoint, content: any) {
     const conduit = (await this.conduitService.get(conduitId))!
-    const provider = (await this.providerService.getById(conduit.providerId))!
+    const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 
     await channel.send(provider.name, endpoint, content)
@@ -166,7 +166,7 @@ export class InstanceService extends Service {
 
   private async handleDispatchStop(conduitId: uuid) {
     const conduit = (await this.conduitService.get(conduitId))!
-    const provider = (await this.providerService.getById(conduit.providerId))!
+    const provider = await this.providerService.getById(conduit.providerId)
     const channel = this.channelService.getById(conduit.channelId)
 
     if (!channel.has(provider.name)) {

--- a/packages/server/src/messages/api.ts
+++ b/packages/server/src/messages/api.ts
@@ -40,7 +40,7 @@ export class MessageApi {
     }
 
     if (authorId) {
-      const author = await this.users.get(authorId)
+      const author = await this.users.fetch(authorId)
       if (!author || author.clientId !== req.client.id) {
         return res.sendStatus(404)
       }
@@ -74,7 +74,7 @@ export class MessageApi {
       timeout: string
     }
 
-    const author = await this.users.get(authorId)
+    const author = await this.users.fetch(authorId)
     if (!author || author.clientId !== req.client.id) {
       return res.sendStatus(404)
     }

--- a/packages/server/src/messages/api.ts
+++ b/packages/server/src/messages/api.ts
@@ -59,7 +59,7 @@ export class MessageApi {
     const source = authorId
       ? undefined
       : {
-          client: { id: req.client!.id }
+          client: { id: req.client.id }
         }
     const message = await this.messages.create(conversationId, authorId, payload, source, messageId)
 
@@ -158,7 +158,7 @@ export class MessageApi {
     }
 
     const conversation = await this.conversations.fetch(message.conversationId)
-    if (!conversation || conversation.clientId !== req.client!.id) {
+    if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
 

--- a/packages/server/src/messages/api.ts
+++ b/packages/server/src/messages/api.ts
@@ -46,7 +46,7 @@ export class MessageApi {
       }
     }
 
-    const conversation = await this.conversations.get(conversationId)
+    const conversation = await this.conversations.fetch(conversationId)
     if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -79,7 +79,7 @@ export class MessageApi {
       return res.sendStatus(404)
     }
 
-    const conversation = await this.conversations.get(conversationId)
+    const conversation = await this.conversations.fetch(conversationId)
     if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -99,7 +99,7 @@ export class MessageApi {
       return res.sendStatus(404)
     }
 
-    const conversation = await this.conversations.get(message.conversationId)
+    const conversation = await this.conversations.fetch(message.conversationId)
     if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -111,7 +111,7 @@ export class MessageApi {
     const conversationId = req.params.conversationId as uuid
     const limit = +(req.query.limit || 20)
 
-    const conversation = await this.conversations.get(conversationId)
+    const conversation = await this.conversations.fetch(conversationId)
     if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -128,7 +128,7 @@ export class MessageApi {
       return res.sendStatus(404)
     }
 
-    const conversation = await this.conversations.get(message.conversationId)
+    const conversation = await this.conversations.fetch(message.conversationId)
     if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -140,7 +140,7 @@ export class MessageApi {
   async deleteByConversation(req: ClientApiRequest, res: Response) {
     const { conversationId } = req.params
 
-    const conversation = await this.conversations.get(conversationId)
+    const conversation = await this.conversations.fetch(conversationId)
     if (!conversation || conversation.clientId !== req.client.id) {
       return res.sendStatus(404)
     }
@@ -157,7 +157,7 @@ export class MessageApi {
       return res.sendStatus(404)
     }
 
-    const conversation = await this.conversations.get(message.conversationId)
+    const conversation = await this.conversations.fetch(message.conversationId)
     if (!conversation || conversation.clientId !== req.client!.id) {
       return res.sendStatus(404)
     }

--- a/packages/server/src/messages/api.ts
+++ b/packages/server/src/messages/api.ts
@@ -94,7 +94,7 @@ export class MessageApi {
   async get(req: ClientApiRequest, res: Response) {
     const id = req.params.id as uuid
 
-    const message = await this.messages.get(id)
+    const message = await this.messages.fetch(id)
     if (!message) {
       return res.sendStatus(404)
     }
@@ -123,7 +123,7 @@ export class MessageApi {
   async delete(req: ClientApiRequest, res: Response) {
     const id = req.params.id as uuid
 
-    const message = await this.messages.get(id)
+    const message = await this.messages.fetch(id)
     if (!message) {
       return res.sendStatus(404)
     }
@@ -152,7 +152,7 @@ export class MessageApi {
   async turn(req: ClientApiRequest, res: Response) {
     const id = req.params.id as uuid
 
-    const message = await this.messages.get(id)
+    const message = await this.messages.fetch(id)
     if (!message) {
       return res.sendStatus(404)
     }

--- a/packages/server/src/messages/service.ts
+++ b/packages/server/src/messages/service.ts
@@ -68,7 +68,7 @@ export class MessageService extends Service {
 
     await this.batcher.push(message)
     const conversation = await this.conversationService.get(conversationId)
-    await this.conversationService.setMostRecent(conversation!.userId, conversation!.id)
+    await this.conversationService.setMostRecent(conversation.userId, conversation.id)
 
     await this.emitter.emit(MessageEvents.Created, { message, source })
 
@@ -82,7 +82,7 @@ export class MessageService extends Service {
     const conversation = await this.conversationService.get(message.conversationId)
 
     this.cache.del(id, true)
-    this.conversationService.invalidateMostRecent(conversation!.userId)
+    this.conversationService.invalidateMostRecent(conversation.userId)
 
     return this.query().where({ id }).del()
   }
@@ -141,7 +141,7 @@ export class MessageService extends Service {
       deletedIds.forEach((x) => this.cache.del(x, true))
 
       const conversation = await this.conversationService.get(conversationId)
-      this.conversationService.invalidateMostRecent(conversation!.userId)
+      this.conversationService.invalidateMostRecent(conversation.userId)
     }
 
     return deletedIds.length

--- a/packages/server/src/messages/service.ts
+++ b/packages/server/src/messages/service.ts
@@ -128,7 +128,7 @@ export class MessageService extends Service {
     }
 
     const rows = await query
-    return rows.map((x: any) => this.deserialize(x)!)
+    return rows.map((x: any) => this.deserialize(x))
   }
 
   public async deleteByConversationId(conversationId: uuid): Promise<number> {

--- a/packages/server/src/messages/service.ts
+++ b/packages/server/src/messages/service.ts
@@ -79,7 +79,7 @@ export class MessageService extends Service {
     await this.batcher.flush()
 
     const message = await this.get(id)
-    const conversation = await this.conversationService.get(message!.conversationId)
+    const conversation = await this.conversationService.get(message.conversationId)
 
     this.cache.del(id, true)
     this.conversationService.invalidateMostRecent(conversation!.userId)
@@ -87,7 +87,7 @@ export class MessageService extends Service {
     return this.query().where({ id }).del()
   }
 
-  public async get(id: uuid): Promise<Message | undefined> {
+  public async fetch(id: uuid): Promise<Message | undefined> {
     const cached = this.cache.get(id)
     if (cached) {
       return cached
@@ -105,6 +105,14 @@ export class MessageService extends Service {
     }
 
     return undefined
+  }
+
+  public async get(id: uuid): Promise<Message> {
+    const val = await this.fetch(id)
+    if (!val) {
+      throw new Error(`Message ${id} not found`)
+    }
+    return val
   }
 
   public async listByConversationId(conversationId: uuid, limit?: number, offset?: number): Promise<Message[]> {

--- a/packages/server/src/messages/socket.ts
+++ b/packages/server/src/messages/socket.ts
@@ -17,7 +17,7 @@ export class MessageSocket {
 
   async create(socket: SocketRequest) {
     const { conversationId, payload } = socket.data
-    const conversation = await this.conversations.get(conversationId)
+    const conversation = await this.conversations.fetch(conversationId)
 
     if (!conversation || conversation.userId !== socket.userId) {
       return socket.notFound('Conversation does not exist')
@@ -31,7 +31,7 @@ export class MessageSocket {
 
   async list(socket: SocketRequest) {
     const { conversationId, limit } = socket.data
-    const conversation = await this.conversations.get(conversationId)
+    const conversation = await this.conversations.fetch(conversationId)
 
     if (!conversation || conversation.userId !== socket.userId) {
       return socket.notFound('Conversation does not exist')

--- a/packages/server/src/messages/stream.ts
+++ b/packages/server/src/messages/stream.ts
@@ -27,13 +27,13 @@ export class MessageStream {
     await this.streamer.stream(
       'message.new',
       {
-        channel: await this.getChannel(conversation!.id),
-        conversationId: conversation!.id,
+        channel: await this.getChannel(conversation.id),
+        conversationId: conversation.id,
         collect: this.converse.isCollectingForMessage(message.id),
         message
       },
-      conversation!.clientId,
-      conversation!.userId,
+      conversation.clientId,
+      conversation.userId,
       source
     )
   }

--- a/packages/server/src/providers/service.ts
+++ b/packages/server/src/providers/service.ts
@@ -40,7 +40,7 @@ export class ProviderService extends Service {
     return provider
   }
 
-  async getByName(name: string): Promise<Provider | undefined> {
+  async fetchByName(name: string): Promise<Provider | undefined> {
     const cached = this.cacheByName.get(name)
     if (cached) {
       return cached
@@ -59,7 +59,15 @@ export class ProviderService extends Service {
     return undefined
   }
 
-  async getById(id: uuid): Promise<Provider | undefined> {
+  async getByName(name: string): Promise<Provider> {
+    const val = await this.fetchByName(name)
+    if (!val) {
+      throw new Error(`Provider with name ${name} not found`)
+    }
+    return val
+  }
+
+  async fetchById(id: uuid): Promise<Provider | undefined> {
     const cached = this.cacheById.get(id)
     if (cached) {
       return cached
@@ -78,8 +86,16 @@ export class ProviderService extends Service {
     return undefined
   }
 
+  async getById(id: string): Promise<Provider> {
+    const val = await this.fetchById(id)
+    if (!val) {
+      throw new Error(`Provider ${id} not found`)
+    }
+    return val
+  }
+
   async updateSandbox(id: uuid, sandbox: boolean) {
-    const oldProvider = (await this.getById(id))!
+    const oldProvider = await this.getById(id)
 
     this.cacheById.del(id, true)
     this.cacheByName.del(oldProvider.name, true)
@@ -91,7 +107,7 @@ export class ProviderService extends Service {
   }
 
   async updateName(id: uuid, name: string) {
-    const oldProvider = (await this.getById(id))!
+    const oldProvider = await this.getById(id)
 
     this.cacheById.del(id, true)
     this.cacheByName.del(oldProvider.name, true)
@@ -103,7 +119,7 @@ export class ProviderService extends Service {
   async delete(id: uuid) {
     await this.emitter.emit(ProviderEvents.Deleting, { providerId: id })
 
-    const provider = (await this.getById(id))!
+    const provider = await this.getById(id)
     this.cacheById.del(id, true)
     this.cacheByName.del(provider.name, true)
 

--- a/packages/server/src/socket/manager.ts
+++ b/packages/server/src/socket/manager.ts
@@ -33,16 +33,15 @@ export class SocketManager {
   }
 
   async destroy() {
-    if (!this.ws) {
-      return
-    }
-
     await new Promise((resolve, reject) => {
+      if (!this.ws) {
+        return
+      }
       // This is kind of hack to make sure that socket.io does not
       // try to close the HTTP server before http-terminator
-      this.ws!['httpServer'] = undefined
+      this.ws['httpServer'] = undefined
 
-      this.ws!.close((err) => {
+      this.ws.close((err) => {
         if (err) {
           this.logger.error(err, 'An error occurred when closing the websocket server.')
         }

--- a/packages/server/src/socket/manager.ts
+++ b/packages/server/src/socket/manager.ts
@@ -97,7 +97,7 @@ export class SocketManager {
       }
 
       if (creds) {
-        const user = await this.users.get(creds.userId)
+        const user = await this.users.fetch(creds.userId)
         if (user?.clientId === clientId) {
           const [userTokenId, userTokenToken] = creds.userToken.split('.')
           if (

--- a/packages/server/src/socket/manager.ts
+++ b/packages/server/src/socket/manager.ts
@@ -91,7 +91,7 @@ export class SocketManager {
         creds?: { userId: uuid; userToken: string }
       }
 
-      const client = await this.clients.getById(clientId)
+      const client = await this.clients.fetchById(clientId)
       if (!client) {
         return next(new Error('Client not found'))
       }

--- a/packages/server/src/socket/service.ts
+++ b/packages/server/src/socket/service.ts
@@ -49,9 +49,9 @@ export class SocketService extends Service {
   }
 
   public async delete(socket: Socket) {
-    const state = this.sockets[socket.id]!
+    const state = this.sockets[socket.id]
 
-    if (state.userId) {
+    if (state?.userId) {
       const current = this.socketsByUserId[state.userId]
       this.socketsByUserId[state.userId] = (current || []).filter((x) => x.id !== socket.id)
       this.cacheByUserId.del(state.userId)

--- a/packages/server/src/status/service.ts
+++ b/packages/server/src/status/service.ts
@@ -45,7 +45,7 @@ export class StatusService extends Service {
     return status
   }
 
-  async get(conduitId: uuid): Promise<ConduitStatus | undefined> {
+  async fetch(conduitId: uuid): Promise<ConduitStatus | undefined> {
     const cached = this.cache.get(conduitId)
     if (cached) {
       return cached
@@ -63,7 +63,7 @@ export class StatusService extends Service {
 
   async updateInitializedOn(conduitId: uuid, date: Date | undefined) {
     await this.distributed.using(`lock_dyn_status::${conduitId}`, async () => {
-      if (!(await this.get(conduitId))) {
+      if (!(await this.fetch(conduitId))) {
         await this.create(conduitId)
       }
 
@@ -76,7 +76,7 @@ export class StatusService extends Service {
 
   async addError(conduitId: uuid, error: Error) {
     await this.distributed.using(`lock_dyn_status::${conduitId}`, async () => {
-      const status = (await this.get(conduitId)) || (await this.create(conduitId))
+      const status = (await this.fetch(conduitId)) || (await this.create(conduitId))
       const formattedError = this.formatError(error)
 
       await this.query()
@@ -88,7 +88,7 @@ export class StatusService extends Service {
 
   async clearErrors(conduitId: uuid) {
     await this.distributed.using(`lock_dyn_status::${conduitId}`, async () => {
-      const status = await this.get(conduitId)
+      const status = await this.fetch(conduitId)
       if (!status) {
         return
       }

--- a/packages/server/src/sync/api.ts
+++ b/packages/server/src/sync/api.ts
@@ -44,7 +44,7 @@ export class SyncApi {
     // A sync request will accept a incorrect client id (we assume the client was deleted a provide a new client id in response)
     // A sync request will also accept no client id (we assume the caller wants a new client id and we send it as a response)
     if (sync.id) {
-      const client = await this.clients.getById(sync.id)
+      const client = await this.clients.fetchById(sync.id)
       if (client && (!sync.token || !(await this.clients.getByIdAndToken(sync.id, sync.token)))) {
         return res.sendStatus(403)
       }

--- a/packages/server/src/sync/service.ts
+++ b/packages/server/src/sync/service.ts
@@ -129,7 +129,7 @@ export class SyncService extends Service {
     forceProviderName?: string,
     forceClientId?: uuid,
     forceToken?: string
-  ): Promise<Client & { token?: string }> {
+  ): Promise<Omit<Client, 'token'> & { token?: string }> {
     let client: Client | undefined = undefined
     let token: string | undefined = undefined
     let provider: Provider | undefined = undefined

--- a/packages/server/src/sync/service.ts
+++ b/packages/server/src/sync/service.ts
@@ -80,7 +80,7 @@ export class SyncService extends Service {
   }
 
   private async syncProvider(name: string, sandbox: boolean): Promise<Provider> {
-    let provider = await this.providers.getByName(name)
+    let provider = await this.providers.fetchByName(name)
 
     if (!provider) {
       provider = await this.providers.create(name, sandbox)
@@ -140,7 +140,7 @@ export class SyncService extends Service {
 
     // For when messaging is spinned. Assures that a certain botId always gets back the same clientId when calling messaging
     if (!client && forceProviderName && !forceClientId) {
-      const exisingProvider = await this.providers.getByName(forceProviderName)
+      const exisingProvider = await this.providers.fetchByName(forceProviderName)
       if (exisingProvider) {
         const existingClient = await this.clients.getByProviderId(exisingProvider.id)
         if (existingClient) {
@@ -158,7 +158,7 @@ export class SyncService extends Service {
       token = forceToken || (await this.clients.generateToken())
       client = await this.clients.create(provider.id, token, clientId)
     } else {
-      provider = await this.providers.getById(client.providerId)
+      provider = await this.providers.fetchById(client.providerId)
 
       if (!provider) {
         provider = await this.providers.create(client.id, false)
@@ -173,7 +173,7 @@ export class SyncService extends Service {
       // If this provider's name conflicts with an old provider, we delete the old provider
       // We only do this when setting a name ourselves to the provider (meaning we made a call to sync with sufficient authority)
       if (forceProviderName) {
-        const providerWithSameName = await this.providers.getByName(targetName)
+        const providerWithSameName = await this.providers.fetchByName(targetName)
         if (providerWithSameName && providerWithSameName.id !== provider.id) {
           await this.providers.delete(providerWithSameName.id)
         }

--- a/packages/server/src/sync/service.ts
+++ b/packages/server/src/sync/service.ts
@@ -109,7 +109,7 @@ export class SyncService extends Service {
       if (oldConduitIndex < 0) {
         await this.conduits.create(providerId, channelId, configWithoutEnabled)
       } else {
-        const oldConduit = (await this.conduits.getByProviderAndChannel(providerId, channelId))!
+        const oldConduit = await this.conduits.getByProviderAndChannel(providerId, channelId)
 
         if (!_.isEqual(configWithoutEnabled, oldConduit.config)) {
           await this.conduits.updateConfig(oldConduit.id, configWithoutEnabled)

--- a/packages/server/src/sync/service.ts
+++ b/packages/server/src/sync/service.ts
@@ -135,14 +135,14 @@ export class SyncService extends Service {
     let provider: Provider | undefined = undefined
 
     if (clientId) {
-      client = await this.clients.getById(clientId)
+      client = await this.clients.fetchById(clientId)
     }
 
     // For when messaging is spinned. Assures that a certain botId always gets back the same clientId when calling messaging
     if (!client && forceProviderName && !forceClientId) {
       const exisingProvider = await this.providers.fetchByName(forceProviderName)
       if (exisingProvider) {
-        const existingClient = await this.clients.getByProviderId(exisingProvider.id)
+        const existingClient = await this.clients.fetchByProviderId(exisingProvider.id)
         if (existingClient) {
           token = forceToken || (await this.clients.generateToken())
           await this.clients.updateToken(existingClient.id, token)
@@ -164,7 +164,7 @@ export class SyncService extends Service {
         provider = await this.providers.create(client.id, false)
 
         await this.clients.updateProvider(client.id, provider.id)
-        client = (await this.clients.getById(client.id))!
+        client = await this.clients.getById(client.id)
       }
     }
 

--- a/packages/server/src/user-tokens/service.ts
+++ b/packages/server/src/user-tokens/service.ts
@@ -76,7 +76,7 @@ export class UserTokenService extends Service {
     return userToken
   }
 
-  async getById(id: uuid): Promise<UserToken | undefined> {
+  async fetchById(id: uuid): Promise<UserToken | undefined> {
     const cached = this.cacheById.get(id)
     if (cached) {
       return cached
@@ -95,7 +95,7 @@ export class UserTokenService extends Service {
   }
 
   async verifyToken(id: string, token: string): Promise<UserToken | undefined> {
-    const userToken = await this.getById(id)
+    const userToken = await this.fetchById(id)
     if (!userToken) {
       return undefined
     }

--- a/packages/server/src/users/api.ts
+++ b/packages/server/src/users/api.ts
@@ -21,7 +21,7 @@ export class UserApi {
   async get(req: ClientApiRequest, res: Response) {
     const id = req.params.id as uuid
 
-    const user = await this.users.get(id)
+    const user = await this.users.fetch(id)
     if (!user || user.clientId !== req.client.id) {
       return res.sendStatus(404)
     }

--- a/packages/server/src/users/service.ts
+++ b/packages/server/src/users/service.ts
@@ -57,7 +57,7 @@ export class UserService extends Service {
     return user
   }
 
-  public async get(id: uuid): Promise<User | undefined> {
+  public async fetch(id: uuid): Promise<User | undefined> {
     const cached = this.cache.get(id)
     if (cached) {
       return cached
@@ -73,6 +73,14 @@ export class UserService extends Service {
     }
 
     return undefined
+  }
+
+  public async get(id: uuid): Promise<User> {
+    const val = await this.fetch(id)
+    if (!val) {
+      throw new Error(`User ${id} not found`)
+    }
+    return val
   }
 
   private query() {

--- a/packages/server/src/webhooks/service.ts
+++ b/packages/server/src/webhooks/service.ts
@@ -36,7 +36,7 @@ export class WebhookService extends Service {
       token
     }
 
-    await this.query().insert(await this.serialize(webhook))
+    await this.query().insert(this.serialize(webhook))
 
     this.cacheListByClient.del(clientId, true)
 
@@ -81,10 +81,10 @@ export class WebhookService extends Service {
     return webhooks
   }
 
-  private serialize(webhook: Partial<Webhook>) {
+  private serialize(webhook: Webhook) {
     return {
       ...webhook,
-      token: this.cryptoService.encrypt(webhook.token!)
+      token: this.cryptoService.encrypt(webhook.token)
     }
   }
 

--- a/packages/server/src/webhooks/service.ts
+++ b/packages/server/src/webhooks/service.ts
@@ -43,7 +43,7 @@ export class WebhookService extends Service {
     return webhook
   }
 
-  async get(id: uuid): Promise<Webhook | undefined> {
+  async fetch(id: uuid): Promise<Webhook | undefined> {
     const rows = await this.query().where({ id })
     if (rows?.length) {
       return this.deserialize(rows[0])
@@ -52,9 +52,17 @@ export class WebhookService extends Service {
     }
   }
 
+  async get(id: uuid): Promise<Webhook> {
+    const val = await this.fetch(id)
+    if (!val) {
+      throw new Error(`Webhook ${id} not found`)
+    }
+    return val
+  }
+
   async delete(id: uuid) {
     const webhook = await this.get(id)
-    this.cacheListByClient.del(webhook!.clientId, true)
+    this.cacheListByClient.del(webhook.clientId, true)
 
     return this.query().where({ id }).del()
   }

--- a/packages/server/test/integration/providers.test.ts
+++ b/packages/server/test/integration/providers.test.ts
@@ -120,11 +120,11 @@ describe('Providers', () => {
     await providers.delete(state.provider!.id)
     const calls = querySpy.mock.calls.length
 
-    const notCachedById = await providers.getById(state.provider!.id)
+    const notCachedById = await providers.fetchById(state.provider!.id)
     expect(notCachedById).toBeUndefined()
     expect(querySpy).toHaveBeenCalledTimes(calls + 1)
 
-    const notCachedByName = await providers.getByName(state.provider!.name)
+    const notCachedByName = await providers.fetchByName(state.provider!.name)
     expect(notCachedByName).toBeUndefined()
     expect(querySpy).toHaveBeenCalledTimes(calls + 2)
   })

--- a/packages/server/test/integration/status.test.ts
+++ b/packages/server/test/integration/status.test.ts
@@ -48,7 +48,7 @@ describe('Status', () => {
   })
 
   test('Get status of new conduit should be undefined', async () => {
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
     expect(st).toBeUndefined()
   })
 
@@ -64,7 +64,7 @@ describe('Status', () => {
   })
 
   test('Get status', async () => {
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
 
     expect(st).toEqual(state.status)
   })
@@ -80,7 +80,7 @@ describe('Status', () => {
   })
 
   test('Create status for other conduit', async () => {
-    let st = await status.get(state.conduit2.id)
+    let st = await status.fetch(state.conduit2.id)
     expect(st).toBeUndefined()
 
     st = await status.create(state.conduit2.id)
@@ -103,7 +103,7 @@ describe('Status', () => {
     const errMessage = 'err1'
     await status.addError(state.conduit.id, new Error(errMessage))
 
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
     expect(st!.numberOfErrors).toBe(1)
     expect(st!.lastError?.includes(errMessage)).toBeTruthy()
 
@@ -114,7 +114,7 @@ describe('Status', () => {
     const errMessage = 'err2'
     await status.addError(state.conduit.id, new Error(errMessage))
 
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
     expect(st!.numberOfErrors).toBe(2)
     expect(st!.lastError?.includes(errMessage)).toBeTruthy()
 
@@ -127,7 +127,7 @@ describe('Status', () => {
     const errMessage = 'err5'
     await status.addError(state.conduit.id, new Error(errMessage))
 
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
     expect(st!.numberOfErrors).toBe(MAX_ERRORS)
     expect(st!.lastError?.includes(errMessage)).toBeTruthy()
 
@@ -150,7 +150,7 @@ describe('Status', () => {
   test('Clear errors', async () => {
     await status.clearErrors(state.conduit.id)
 
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
     expect(st!.numberOfErrors).toBe(0)
     expect(st!.lastError).toBeUndefined()
 
@@ -167,7 +167,7 @@ describe('Status', () => {
     const date = new Date()
     await status.updateInitializedOn(state.conduit.id, date)
 
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
     expect(st!.initializedOn).toEqual(date)
 
     state.status = st
@@ -189,7 +189,7 @@ describe('Status', () => {
     const date = new Date()
     await status.updateInitializedOn(state.conduit2.id, date)
 
-    const st = await status.get(state.conduit2.id)
+    const st = await status.fetch(state.conduit2.id)
     expect(st!.initializedOn).toEqual(date)
 
     state.status2 = st
@@ -210,7 +210,7 @@ describe('Status', () => {
   test('Set intializedOn to null', async () => {
     await status.updateInitializedOn(state.conduit.id, undefined)
 
-    const st = await status.get(state.conduit.id)
+    const st = await status.fetch(state.conduit.id)
     expect(st!.initializedOn).toBeUndefined()
 
     state.status = st

--- a/packages/server/test/integration/user-tokens.test.ts
+++ b/packages/server/test/integration/user-tokens.test.ts
@@ -59,18 +59,18 @@ describe('UserTokens', () => {
   })
 
   test('Get user token by id', async () => {
-    const userToken = await app.userTokens.getById(state.userToken!.id)
+    const userToken = await app.userTokens.fetchById(state.userToken!.id)
     expect(userToken).toEqual(state.userToken)
     expect(querySpy).toHaveBeenCalledTimes(1)
   })
 
   test('Get user token by id cached', async () => {
-    const userToken = await app.userTokens.getById(state.userToken!.id)
+    const userToken = await app.userTokens.fetchById(state.userToken!.id)
     expect(userToken).toEqual(state.userToken)
     expect(querySpy).toHaveBeenCalledTimes(1)
 
     for (let i = 0; i < 10; i++) {
-      const userToken = await app.userTokens.getById(state.userToken!.id)
+      const userToken = await app.userTokens.fetchById(state.userToken!.id)
       expect(userToken).toEqual(state.userToken)
     }
 
@@ -115,7 +115,7 @@ describe('UserTokens', () => {
   })
 
   test('Get user token by id with outdated expiry', async () => {
-    const userToken = await app.userTokens.getById(state.userToken!.id)
+    const userToken = await app.userTokens.fetchById(state.userToken!.id)
     expect(userToken).toEqual(state.userToken)
     expect(querySpy).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
We had way too many not nulls everywhere in the code, so this PR seperates all our `get` functions into `get` and `fetch`. A fetch functions is going to try to get the data, and return undefined if it doesn't find it. The get function will use the fetch function, and if the fetch function returns undefined, it will throw an error. This way we can use the get function in places in the code where we expect the get function to return a value, and remove all our not nulls. If for any reason the get function fails, it returns a clear message and prevents the request from running any longer with garbage data.

Closes DEV-2166