### PR TITLE
chore(conversations): remove /recent route

### DIFF
--- a/doc/routes.md
+++ b/doc/routes.md
@@ -130,14 +130,6 @@ x-bp-messaging-client-token: `clientToken`
 
 Lists the conversations of a user
 
-GET `/api/conversations/user/:userId/recent`
-
-x-bp-messaging-client-id: `clientId`
-
-x-bp-messaging-client-token: `clientToken`
-
-Gets the most recent conversation of a user
-
 ## Messages
 
 POST `/api/messages`

--- a/packages/client/src/conversations.ts
+++ b/packages/client/src/conversations.ts
@@ -20,7 +20,9 @@ export class ConversationClient extends BaseClient {
   }
 
   async getRecent(userId: string): Promise<Conversation> {
-    return this.deserialize((await this.http.get<Conversation>(`/conversations/user/${userId}/recent`)).data)
+    return (await this.http.get<Conversation[]>(`/conversations/user/${userId}`, { params: { limit: 1 } })).data.map(
+      (x) => this.deserialize(x)
+    )[0]
   }
 
   private deserialize(conversation: Conversation): Conversation {

--- a/packages/server/src/conversations/api.ts
+++ b/packages/server/src/conversations/api.ts
@@ -15,8 +15,6 @@ export class ConversationApi {
     router.post('/conversations', Schema.Api.Create, this.create.bind(this))
     router.get('/conversations/:id', Schema.Api.Get, this.get.bind(this))
     router.get('/conversations/user/:userId', Schema.Api.List, this.list.bind(this))
-    // TODO: remove this route
-    router.get('/conversations/user/:userId/recent', Schema.Api.Recent, this.recent.bind(this))
   }
 
   async create(req: ClientApiRequest, res: Response) {
@@ -53,21 +51,5 @@ export class ConversationApi {
 
     const conversations = await this.conversations.listByUserId(req.clientId, userId, limit)
     res.send(conversations)
-  }
-
-  async recent(req: ClientApiRequest, res: Response) {
-    const userId = req.params.userId as uuid
-
-    const user = await this.users.fetch(userId)
-    if (!user || user.clientId !== req.clientId) {
-      return res.sendStatus(404)
-    }
-
-    let conversation = await this.conversations.fetchMostRecent(req.clientId, userId)
-    if (!conversation) {
-      conversation = await this.conversations.create(req.clientId, userId)
-    }
-
-    res.send(conversation)
   }
 }

--- a/packages/server/src/conversations/schema.ts
+++ b/packages/server/src/conversations/schema.ts
@@ -13,10 +13,6 @@ const Api = {
   List: ReqSchema({
     params: { userId: Joi.string().guid().required() },
     query: { limit: Joi.number().min(0).optional() }
-  }),
-
-  Recent: ReqSchema({
-    params: { userId: Joi.string().guid().required() }
   })
 }
 

--- a/packages/server/test/integration/conversations.test.ts
+++ b/packages/server/test/integration/conversations.test.ts
@@ -66,25 +66,6 @@ describe('Conversations', () => {
     expect(querySpy).toHaveBeenCalledTimes(1)
   })
 
-  test('Get most recent conversation', async () => {
-    const conversation = await conversations.fetchMostRecent(state.client.id, state.user!.id)
-    expect(conversation).toEqual(state.conversation)
-    expect(querySpy).toHaveBeenCalledTimes(1)
-  })
-
-  test('Get conversation by id cached', async () => {
-    const conversation = await conversations.fetchMostRecent(state.client.id, state.user!.id)
-    expect(conversation).toEqual(state.conversation)
-    expect(querySpy).toHaveBeenCalledTimes(1)
-
-    for (let i = 0; i < 10; i++) {
-      const cached = await conversations.fetchMostRecent(state.client.id, state.user!.id)
-      expect(cached).toEqual(state.conversation)
-    }
-
-    expect(querySpy).toHaveBeenCalledTimes(1)
-  })
-
   test('List conversations by user', async () => {
     const user = await users.create(state.client.id)
     const convo1 = await conversations.create(state.client.id, user.id)
@@ -104,9 +85,5 @@ describe('Conversations', () => {
     const notCachedById = await conversations.fetch(state.conversation!.id)
     expect(notCachedById).toBeUndefined()
     expect(querySpy).toHaveBeenCalledTimes(calls + 1)
-
-    const notCachedByRecent = await conversations.fetchMostRecent(state.client.id, state.user.id)
-    expect(notCachedByRecent).toBeUndefined()
-    expect(querySpy).toHaveBeenCalledTimes(calls + 2)
   })
 })

--- a/packages/server/test/security/api.test.ts
+++ b/packages/server/test/security/api.test.ts
@@ -386,24 +386,6 @@ describe('API', () => {
       return res.data
     }
 
-    const recentConversation = async (
-      conversationId: string,
-      userId: string,
-      clientId?: string,
-      clientToken?: string,
-      config?: AxiosRequestConfig
-    ) => {
-      const res = await http(clientId, clientToken).get<Conversation>(
-        `/api/conversations/user/${userId}/recent`,
-        config
-      )
-
-      expect(res.data).toEqual({ id: conversationId, clientId, userId, createdOn: expect.anything() })
-      expect(res.status).toEqual(200)
-
-      return res.data
-    }
-
     describe('Create', () => {
       test('Should be able to create a conversation with valid credentials', async () => {
         const res = await conversation(clients.first.userId, clients.first.clientId, clients.first.clientToken)
@@ -574,63 +556,6 @@ describe('API', () => {
           (err) => {
             expect(err.response?.data).toEqual('"query.limit" must be a safe number')
             expect(err.response?.status).toEqual(400)
-          }
-        )
-      })
-    })
-
-    describe('Recent', () => {
-      test('Should be able to fetch the most recent conversation with valid credentials', async () => {
-        await recentConversation(
-          clients.first.conversationId,
-          clients.first.userId,
-          clients.first.clientId,
-          clients.first.clientToken
-        )
-        await recentConversation(
-          clients.second.conversationId,
-          clients.second.userId,
-          clients.second.clientId,
-          clients.second.clientToken
-        )
-      })
-
-      test('Should not be able to fetch the most recent conversation without being authenticated', async () => {
-        await shouldFail(
-          async () => recentConversation(clients.first.conversationId, clients.first.userId),
-          (err) => {
-            expect(err.response?.data).toEqual('Unauthorized')
-
-            expect(err.response?.status).toEqual(401)
-          }
-        )
-      })
-
-      test('Should not be able to fetch the most recent conversation for a user that does not exists', async () => {
-        await shouldFail(
-          async () =>
-            recentConversation(clients.first.conversationId, uuid(), clients.first.clientId, clients.first.clientToken),
-          (err) => {
-            expect(err.response?.data).toEqual('Not Found')
-
-            expect(err.response?.status).toEqual(404)
-          }
-        )
-      })
-
-      test('Should not be able to fetch the most recent conversation of a user from another client', async () => {
-        await shouldFail(
-          async () =>
-            recentConversation(
-              clients.second.conversationId,
-              clients.second.userId,
-              clients.first.clientId,
-              clients.first.clientToken
-            ),
-          (err) => {
-            expect(err.response?.data).toEqual('Not Found')
-
-            expect(err.response?.status).toEqual(404)
           }
         )
       })


### PR DESCRIPTION
Removes the /recent route from the conversation api since it can be directly replace by listing the conversations and limiting to 1

Closes DEV-2221