### PR TITLE
chore(ci_cd): make sure whole new changelog is passed as body on new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
         id: release_details
         uses: botpress/gh-actions/get_release_details@v1
 
-      - name: Fix Change Log
+      - name: Display Release Details
         id: changelog
         run: |
-          echo "::set-output name=value::${{ steps.release_details.outputs.changelog }}"
+          echo "Changelog: ${{ steps.release_details.outputs.changelog }}"
           echo "Is new release?: ${{ steps.release_details.outputs.is_new_release }}"
           echo "Version: ${{ steps.release_details.outputs.version }}"
           echo "Latest Tag: ${{ steps.release_details.outputs.latest_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           files: ./bin/messaging-v*
           prerelease: false
           draft: false
-          body: ${{ steps.changelog.outputs.value }}
+          body: ${{ steps.release_details.outputs.changelog }}
           name: v${{ steps.release_details.outputs.version }}
           tag_name: v${{ steps.release_details.outputs.version }}
         env:


### PR DESCRIPTION
Basically, if you go see the [releases](https://github.com/botpress/messaging/releases), you'll see that a lot of release notes are missing. This seems to be due to the fact that the variable we passed as body to the release action would strip the changelog because of a `\n` or some other break line. Since the tests made were using this output variable as the body of the release, I take for granted that it will fix the issue. 