### PR TITLE
fix(server): fix server not closing when spinned

### DIFF
--- a/.yarn/versions/2c52e3b6.yml
+++ b/.yarn/versions/2c52e3b6.yml
@@ -1,0 +1,2 @@
+undecided:
+  - "@botpress/messaging"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.1.23](https://github.com/botpress/messaging/compare/v0.1.22...v0.1.23) (2022-01-19)
+
+
+### Bug Fixes
+
+* **server:** fix server not closing when spinned ([4bd6a6f](https://github.com/botpress/messaging/commit/4bd6a6fb9ea48a6792b29c0ea05f2485f2f6b4d2))
+
+
+
 ## [0.1.22](https://github.com/botpress/messaging/compare/v0.1.21...v0.1.22) (2022-01-18)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Botpress messaging repo",
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-server",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/server/src/launcher.ts
+++ b/packages/server/src/launcher.ts
@@ -104,7 +104,9 @@ export class Launcher {
   }
 
   async shutDown(code?: number) {
-    if (!this.shuttingDown && !yn(process.env.SPINNED)) {
+    if (yn(process.env.SPINNED)) {
+      process.exit(code)
+    } else if (!this.shuttingDown) {
       this.shuttingDown = true
 
       try {


### PR DESCRIPTION
FIxes a bug introduced in #312 that would prevent the server from ever closing when spinned from botpress.