### PR TITLE
fix(conversations): fix ordering

### DIFF
--- a/packages/server/src/conversations/service.ts
+++ b/packages/server/src/conversations/service.ts
@@ -142,7 +142,7 @@ export class ConversationService extends Service {
       .leftJoin(
         `${getTableId('msg_messages')}`,
         `${getTableId('msg_messages')}.conversationId`,
-        `${getTableId('msg_messages')}.id`
+        `${getTableId('msg_conversations')}.id`
       )
       .where({
         clientId,


### PR DESCRIPTION
I messed up the conversation listing in the conversation service when I added added the getTableId function. Basically the conversations were not listed in order of most recently used anymore, so I fixed it and added a test to prevent it from not working again