### PR TITLE
fix(client): strip unknown data received from webhook

### DIFF
--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -8,7 +8,8 @@ export const Schemas = {
     .object({
       userId: joi.string().guid().required()
     })
-    .required() as any,
+    .required()
+    .options({ stripUnknown: true }) as any,
 
   ConversationStarted: joi
     .object({
@@ -16,7 +17,8 @@ export const Schemas = {
       conversationId: joi.string().guid().required(),
       channel: joi.string().required()
     })
-    .required() as any,
+    .required()
+    .options({ stripUnknown: true }) as any,
 
   MessageNew: joi
     .object({
@@ -34,5 +36,6 @@ export const Schemas = {
         })
         .required()
     })
-    .required() as any
+    .required()
+    .options({ stripUnknown: true }) as any
 }


### PR DESCRIPTION
Since the messaging api might add stuff to its webhook payload, we shouldn't enforce that unknown keys are not present in the payload since this would prevent us in the future from upgrading the messaging api without having to upgrade everything that listens to its events at the same time.

The contract of compatibility with the API user is : when making a request, the data that you were previously sent back will always be sent back, but don't assume that any additional data will not be added to the response in the future. This applies to webhooks as well. We don't guarantee the API user that more data will not be added to the webooks payload, but we assure that the data that was there in the past will still be there.

When making API request, we don't use stripUnknown because it is not part of the contract. We are free to add additional fields later that we accept in request, but older versions of the API shouldn't accept them.

This contract assures compatibility of the API when moving from a older version to a newer version of the messaging API. 

Closes DEV-2274