### PR TITLE
feat(channels): remove experimental channels feature flag

### DIFF
--- a/packages/server/src/channels/service.ts
+++ b/packages/server/src/channels/service.ts
@@ -6,7 +6,8 @@ import {
   SmoochChannel,
   TeamsChannel,
   TelegramChannel,
-  TwilioChannel
+  TwilioChannel,
+  VonageChannel
 } from '@botpress/messaging-channels'
 import {
   MessengerChannel as MessengerChannelLegacy,
@@ -35,19 +36,15 @@ export class ChannelService extends Service {
 
     this.table = new ChannelTable()
 
-    this.channels = []
-
-    if (yn(process.env.ENABLE_EXPERIMENTAL_CHANNELS)) {
-      this.channels = [
-        ...this.channels,
-        new MessengerChannel(),
-        new SlackChannel(),
-        new TeamsChannel(),
-        new TelegramChannel(),
-        new TwilioChannel(),
-        new SmoochChannel()
-      ]
-    }
+    this.channels = [
+      new MessengerChannel(),
+      new SlackChannel(),
+      new TeamsChannel(),
+      new TelegramChannel(),
+      new TwilioChannel(),
+      new SmoochChannel(),
+      new VonageChannel()
+    ]
 
     if (!yn(process.env.DISABLE_LEGACY_CHANNELS)) {
       this.channels = [


### PR DESCRIPTION
This PR removes the experimental channels feature flag so that v1 channels are now enabled by default. This is the first step to enable support for v1 channels inside Botpress.

Note: Will require a new patch release once this is merged.

Related to DEV-2326