### PR TITLE
chore(api): add /v1 to api paths

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/packages/client/src/base.ts
+++ b/packages/client/src/base.ts
@@ -62,7 +62,7 @@ export abstract class MessagingChannelBase extends Emitter<{
   }
 
   private getAxiosConfig({ url, axios }: MessagingChannelOptions): AxiosRequestConfig {
-    const defaultConfig: AxiosRequestConfig = { baseURL: `${url}/api` }
+    const defaultConfig: AxiosRequestConfig = { baseURL: `${url}/api/v1` }
     return { ...axios, ...defaultConfig }
   }
 

--- a/packages/client/src/base.ts
+++ b/packages/client/src/base.ts
@@ -45,7 +45,7 @@ export abstract class MessagingChannelBase extends Emitter<{
   protected _options: MessagingChannelOptions
 
   protected http!: AxiosInstance
-  protected auths: { [clientId: uuid]: MessagingClientAuth } = {}
+  protected auths: { [clientId: uuid]: MessagingClientAuth | undefined } = {}
   protected headers: { [clientId: uuid]: any } = {}
   protected adminHeader: any
 

--- a/packages/client/src/base.ts
+++ b/packages/client/src/base.ts
@@ -3,6 +3,7 @@ import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 import { ConversationStartedEvent, MessageNewEvent, UserNewEvent } from '.'
 import { MessagingClientAuth } from './auth'
 import { Emitter } from './emitter'
+import { Logger } from './logger'
 import { MessagingChannelOptions } from './options'
 
 export abstract class MessagingChannelBase extends Emitter<{
@@ -39,6 +40,14 @@ export abstract class MessagingChannelBase extends Emitter<{
   }
   public set axios(val: Omit<AxiosRequestConfig, 'baseURL'> | undefined) {
     this._options.axios = val
+    this.applyOptions()
+  }
+
+  public get logger() {
+    return this._options.logger
+  }
+  public set logger(val: Logger | undefined) {
+    this._options.logger = val
     this.applyOptions()
   }
 

--- a/packages/client/src/channel.ts
+++ b/packages/client/src/channel.ts
@@ -58,7 +58,7 @@ export class MessagingChannel extends MessagingChannelApi {
     const clientId = req.headers['x-bp-messaging-client-id'] as string
     const webhookToken = req.headers['x-bp-messaging-webhook-token'] as string
 
-    if (!webhookToken || webhookToken !== this.auths[clientId].webhookToken) {
+    if (!webhookToken || !this.auths[clientId] || webhookToken !== this.auths[clientId]?.webhookToken) {
       return undefined
     }
 

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -1,0 +1,6 @@
+export interface Logger {
+  info(message: string, data?: any): void
+  debug(message: string, data?: any): void
+  warn(message: string, data?: any): void
+  error(error: Error | undefined | unknown, message?: string, data?: any): void
+}

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -1,6 +1,7 @@
 import { uuid } from '@botpress/messaging-base'
 import { AxiosRequestConfig } from 'axios'
 import { MessagingClientAuth } from './auth'
+import { Logger } from './logger'
 
 export interface MessagingChannelOptions {
   /** Base url of the messaging server */
@@ -9,6 +10,8 @@ export interface MessagingChannelOptions {
   adminKey?: string
   /** A custom axios config giving more control over the HTTP client used internally. Optional */
   axios?: Omit<AxiosRequestConfig, 'baseURL'>
+  /** Optional logger interface that can be used to get better debugging */
+  logger?: Logger
 }
 
 export interface MessagingOptions extends Omit<MessagingChannelOptions, 'adminKey'>, MessagingClientAuth {

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -49,7 +49,7 @@ export class Api {
 
     this.root.get('/version', this.version.bind(this))
     this.root.get('/status', this.status.bind(this))
-    this.root.use('/api', this.router)
+    this.root.use('/api/v1', this.router)
     this.router.use(
       cors({
         origin: '*',

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -50,6 +50,7 @@ export class Api {
     this.root.get('/version', this.version.bind(this))
     this.root.get('/status', this.status.bind(this))
     this.root.use('/api/v1', this.router)
+    this.root.use('/api', this.router)
     this.router.use(
       cors({
         origin: '*',

--- a/packages/server/src/base/api/utils.ts
+++ b/packages/server/src/base/api/utils.ts
@@ -1,8 +1,0 @@
-import { NextFunction, Request, Response } from 'express'
-
-export const methodNotAllowed = (...allowedMethods: string[]) => {
-  return (_req: Request, res: Response, _next: NextFunction) => {
-    res.set('Allow', Object.keys(allowedMethods).join(', ').toUpperCase())
-    res.status(405).send('Method Not Allowed')
-  }
-}

--- a/packages/server/test/security/api.test.ts
+++ b/packages/server/test/security/api.test.ts
@@ -64,7 +64,7 @@ describe('API', () => {
       }
 
       const client = http()
-      const res = await client.post('/api/admin/clients', undefined, options)
+      const res = await client.post('/api/v1/admin/clients', undefined, options)
 
       expect(res.data).toEqual({ id: expect.anything(), token: expect.anything() })
       expect(res.status).toEqual(201)
@@ -114,7 +114,7 @@ describe('API', () => {
     const sync = async (clientId?: string, clientToken?: string, data?: any, config?: AxiosRequestConfig) => {
       const client = http(clientId, clientToken)
 
-      const res = await client.post<SyncResult>('/api/sync', data || {}, config)
+      const res = await client.post<SyncResult>('/api/v1/sync', data || {}, config)
 
       expect(res.data).toEqual({ webhooks: expect.anything() })
       expect(res.status).toEqual(200)
@@ -243,7 +243,7 @@ describe('API', () => {
 
   describe('User', () => {
     const user = async (clientId?: string, clientToken?: string, config?: AxiosRequestConfig) => {
-      const res = await http(clientId, clientToken).post<User>('/api/users', null, config)
+      const res = await http(clientId, clientToken).post<User>('/api/v1/users', null, config)
 
       expect(res.data).toEqual({ id: expect.anything(), clientId })
       expect(res.status).toEqual(201)
@@ -252,7 +252,7 @@ describe('API', () => {
     }
 
     const getUser = async (userId: string, clientId?: string, clientToken?: string, config?: AxiosRequestConfig) => {
-      const res = await http(clientId, clientToken).get<User>(`/api/users/${userId}`, config)
+      const res = await http(clientId, clientToken).get<User>(`/api/v1/users/${userId}`, config)
 
       expect(res.data).toEqual({ id: userId, clientId })
       expect(res.status).toEqual(200)
@@ -346,7 +346,7 @@ describe('API', () => {
       clientToken?: string,
       config?: AxiosRequestConfig
     ) => {
-      const res = await http(clientId, clientToken).post<Conversation>('/api/conversations', { userId }, config)
+      const res = await http(clientId, clientToken).post<Conversation>('/api/v1/conversations', { userId }, config)
 
       expect(res.data).toEqual({ id: expect.anything(), clientId, userId, createdOn: expect.anything() })
       expect(res.status).toEqual(201)
@@ -361,7 +361,7 @@ describe('API', () => {
       clientToken?: string,
       config?: AxiosRequestConfig
     ) => {
-      const res = await http(clientId, clientToken).get<Conversation>(`/api/conversations/${conversationId}`, config)
+      const res = await http(clientId, clientToken).get<Conversation>(`/api/v1/conversations/${conversationId}`, config)
 
       expect(res.data).toEqual({ id: expect.anything(), clientId, userId, createdOn: expect.anything() })
       expect(res.status).toEqual(200)
@@ -379,7 +379,7 @@ describe('API', () => {
     ) => {
       const query = limit ? `?limit=${limit}` : ''
       const res = await http(clientId, clientToken).get<Conversation[]>(
-        `/api/conversations/user/${userId}${query}`,
+        `/api/v1/conversations/user/${userId}${query}`,
         config
       )
 
@@ -576,7 +576,7 @@ describe('API', () => {
       config?: AxiosRequestConfig
     ) => {
       const res = await http(clientId, clientToken).post<Message>(
-        '/api/messages',
+        '/api/v1/messages',
         { conversationId, authorId, payload, incomingId },
         config
       )
@@ -595,7 +595,7 @@ describe('API', () => {
       clientToken?: string,
       config?: AxiosRequestConfig
     ) => {
-      const res = await http(clientId, clientToken).get<Message>(`/api/messages/${messageId}`, config)
+      const res = await http(clientId, clientToken).get<Message>(`/api/v1/messages/${messageId}`, config)
 
       expect(res.data).toEqual({
         id: messageId,
@@ -620,7 +620,7 @@ describe('API', () => {
     ) => {
       const query = limit ? `?limit=${limit}` : ''
       const res = await http(clientId, clientToken).get<Message[]>(
-        `/api/messages/conversation/${conversationId}${query}`,
+        `/api/v1/messages/conversation/${conversationId}${query}`,
         config
       )
 
@@ -642,7 +642,7 @@ describe('API', () => {
       clientToken?: string,
       config?: AxiosRequestConfig
     ) => {
-      const res = await http(clientId, clientToken).get<void>(`/api/messages/${messageId}`, config)
+      const res = await http(clientId, clientToken).get<void>(`/api/v1/messages/${messageId}`, config)
 
       expect(res.data).toBeUndefined()
       expect(res.status).toEqual(204)
@@ -654,7 +654,7 @@ describe('API', () => {
       clientToken?: string,
       config?: AxiosRequestConfig
     ) => {
-      const res = await http(clientId, clientToken).get<void>(`/api/messages/conversation/${conversationId}`, config)
+      const res = await http(clientId, clientToken).get<void>(`/api/v1/messages/conversation/${conversationId}`, config)
 
       expect(res.data).toEqual({ count: 1 })
       expect(res.status).toEqual(200)

--- a/packages/socket/test/e2e/socket.test.ts
+++ b/packages/socket/test/e2e/socket.test.ts
@@ -11,7 +11,7 @@ const createClient = async () => {
     protocol: url.protocol,
     hostname: url.hostname,
     port: url.port,
-    path: '/api/admin/clients',
+    path: '/api/v1/admin/clients',
     method: 'POST',
     headers: { 'x-bp-messaging-admin-key': process.env.ADMIN_KEY }
   }


### PR DESCRIPTION
Adds /v1 to API paths. Is backward compatible with not using /v1. Will require a new release of the http client.

Also should we version the socket connection? Right now the socket connects at the root of our url. Maybe it could connect at `/sockets/v1`?

The client package needs to be updated

Closes DEV-2285
Closes DEV-2323