### PR TITLE
feat(mapping): endpoint api

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -188,3 +188,21 @@ x-bp-messaging-client-id: `clientId`
 x-bp-messaging-client-token: `clientToken`
 
 Deletes all messages of a conversation
+
+## Endpoints
+
+POST `/api/v1/endpoints/map`
+
+x-bp-messaging-client-id: `clientId`
+
+x-bp-messaging-client-token: `clientToken`
+
+Maps an endpoints and returns a conversation id
+
+GET `/api/v1/endpoints/conversation/:conversationId`
+
+x-bp-messaging-client-id: `clientId`
+
+x-bp-messaging-client-token: `clientToken`
+
+List endpoints of a conversation

--- a/misc/api.rest
+++ b/misc/api.rest
@@ -50,6 +50,7 @@ x-bp-messaging-client-token: {{clientToken}}
 {
   "channels": {
     "telegram": {
+      "version": "1.0.0",
       "botToken": "my-telegram-token"
     }
   },
@@ -63,7 +64,7 @@ x-bp-messaging-client-id: {{clientId}}
 x-bp-messaging-client-token: {{clientToken}}
 
 ### Map Endpoint
-POST {{baseUrl}}/api/v1/endpoints
+POST {{baseUrl}}/api/v1/endpoints/map
 Authorization: Bearer {{authToken}}
 x-bp-messaging-client-id: {{clientId}}
 x-bp-messaging-client-token: {{clientToken}}
@@ -75,20 +76,15 @@ Content-Type: application/json
     "version": "1.0.0"
   },
   "identity": "*",
-  "sender": "bob",
-  "thread": "yoy"
+  "sender": "my-sender-id",
+  "thread": "my-thread-id"
 }
 
-### Revmap Endpoint
-POST {{baseUrl}}/api/v1/endpoints/reverse
+### List Endpoints
+POST {{baseUrl}}/api/v1/endpoints/conversation/{{convoId}}
 Authorization: Bearer {{authToken}}
 x-bp-messaging-client-id: {{clientId}}
 x-bp-messaging-client-token: {{clientToken}}
-Content-Type: application/json
-
-{
-  "conversationId": "{{convoId}}"
-}
 
 ### Create User
 POST {{baseUrl}}/api/v1/users

--- a/misc/api.rest
+++ b/misc/api.rest
@@ -62,6 +62,34 @@ Authorization: Bearer {{authToken}}
 x-bp-messaging-client-id: {{clientId}}
 x-bp-messaging-client-token: {{clientToken}}
 
+### Map Endpoint
+POST {{baseUrl}}/api/v1/endpoints
+Authorization: Bearer {{authToken}}
+x-bp-messaging-client-id: {{clientId}}
+x-bp-messaging-client-token: {{clientToken}}
+Content-Type: application/json
+
+{
+  "channel": {
+    "name": "telegram",
+    "version": "1.0.0"
+  },
+  "identity": "*",
+  "sender": "bob",
+  "thread": "yoy"
+}
+
+### Revmap Endpoint
+POST {{baseUrl}}/api/v1/endpoints/reverse
+Authorization: Bearer {{authToken}}
+x-bp-messaging-client-id: {{clientId}}
+x-bp-messaging-client-token: {{clientToken}}
+Content-Type: application/json
+
+{
+  "conversationId": "{{convoId}}"
+}
+
 ### Create User
 POST {{baseUrl}}/api/v1/users
 Authorization: Bearer {{authToken}}

--- a/misc/api.rest
+++ b/misc/api.rest
@@ -81,7 +81,7 @@ Content-Type: application/json
 }
 
 ### List Endpoints
-POST {{baseUrl}}/api/v1/endpoints/conversation/{{convoId}}
+GET {{baseUrl}}/api/v1/endpoints/conversation/{{convoId}}
 Authorization: Bearer {{authToken}}
 x-bp-messaging-client-id: {{clientId}}
 x-bp-messaging-client-token: {{clientToken}}

--- a/packages/base/src/endpoint.ts
+++ b/packages/base/src/endpoint.ts
@@ -1,0 +1,6 @@
+export interface Endpoint {
+  channel: { name: string; version: string }
+  identity: string
+  sender: string
+  thread: string
+}

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -1,5 +1,6 @@
 export * from './conversations'
 export * from './emitter'
+export * from './endpoint'
 export * from './health'
 export * from './messages'
 export * from './sync'

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -124,6 +124,18 @@ export abstract class MessagingChannelApi extends MessagingChannelBase {
       .data.conversationId
   }
 
+  async revmapEndpoint(clientId: uuid, conversationId: uuid): Promise<Endpoint[]> {
+    return (
+      await this.http.post<Endpoint[]>(
+        '/endpoints/reverse',
+        { conversationId },
+        {
+          headers: this.headers[clientId]
+        }
+      )
+    ).data
+  }
+
   protected deserializeHealth(report: HealthReport) {
     for (const channel of Object.keys(report.channels)) {
       report.channels[channel].events = report.channels[channel].events.map((x) => ({ ...x, time: new Date(x.time) }))

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -120,19 +120,16 @@ export abstract class MessagingChannelApi extends MessagingChannelBase {
   }
 
   async mapEndpoint(clientId: uuid, endpoint: Endpoint): Promise<uuid> {
-    return (await this.http.post<{ conversationId: uuid }>('/endpoints', endpoint, { headers: this.headers[clientId] }))
-      .data.conversationId
+    return (
+      await this.http.post<{ conversationId: uuid }>('/endpoints/map', endpoint, { headers: this.headers[clientId] })
+    ).data.conversationId
   }
 
-  async revmapEndpoint(clientId: uuid, conversationId: uuid): Promise<Endpoint[]> {
+  async listEndpoints(clientId: uuid, conversationId: uuid): Promise<Endpoint[]> {
     return (
-      await this.http.post<Endpoint[]>(
-        '/endpoints/reverse',
-        { conversationId },
-        {
-          headers: this.headers[clientId]
-        }
-      )
+      await this.http.get<Endpoint[]>(`/endpoints/conversation/${conversationId}`, {
+        headers: this.headers[clientId]
+      })
     ).data
   }
 

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -1,4 +1,13 @@
-import { Conversation, HealthReport, Message, SyncRequest, SyncResult, User, uuid } from '@botpress/messaging-base'
+import {
+  Conversation,
+  Endpoint,
+  HealthReport,
+  Message,
+  SyncRequest,
+  SyncResult,
+  User,
+  uuid
+} from '@botpress/messaging-base'
 import { MessagingChannelBase } from './base'
 import { handleNotFound } from './errors'
 
@@ -108,6 +117,11 @@ export abstract class MessagingChannelApi extends MessagingChannelBase {
 
   async endTurn(clientId: uuid, id: uuid) {
     await this.http.post(`/messages/turn/${id}`, undefined, { headers: this.headers[clientId] })
+  }
+
+  async mapEndpoint(clientId: uuid, endpoint: Endpoint): Promise<uuid> {
+    return (await this.http.post<{ conversationId: uuid }>('/endpoints', endpoint, { headers: this.headers[clientId] }))
+      .data.conversationId
   }
 
   protected deserializeHealth(report: HealthReport) {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -155,4 +155,8 @@ export class MessagingClient extends ProtectedEmitter<{
   async mapEndpoint(endpoint: Endpoint): Promise<uuid> {
     return this.channel.mapEndpoint(this.clientId, endpoint)
   }
+
+  async revmapEndpoint(conversationId: uuid): Promise<Endpoint[]> {
+    return this.channel.revmapEndpoint(this.clientId, conversationId)
+  }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -159,7 +159,7 @@ export class MessagingClient extends ProtectedEmitter<{
     return this.channel.mapEndpoint(this.clientId, endpoint)
   }
 
-  async revmapEndpoint(conversationId: uuid): Promise<Endpoint[]> {
-    return this.channel.revmapEndpoint(this.clientId, conversationId)
+  async listEndpoints(conversationId: uuid): Promise<Endpoint[]> {
+    return this.channel.listEndpoints(this.clientId, conversationId)
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,13 @@
-import { Conversation, HealthReport, Message, SyncRequest, SyncResult, User, uuid } from '@botpress/messaging-base'
+import {
+  Conversation,
+  Endpoint,
+  HealthReport,
+  Message,
+  SyncRequest,
+  SyncResult,
+  User,
+  uuid
+} from '@botpress/messaging-base'
 import { AxiosRequestConfig } from 'axios'
 import { Router } from 'express'
 import { MessagingChannel } from './channel'
@@ -141,5 +150,9 @@ export class MessagingClient extends ProtectedEmitter<{
 
   async endTurn(id: uuid) {
     return this.channel.endTurn(this.clientId, id)
+  }
+
+  async mapEndpoint(endpoint: Endpoint): Promise<uuid> {
+    return this.channel.mapEndpoint(this.clientId, endpoint)
   }
 }

--- a/packages/client/test/e2e/client.test.ts
+++ b/packages/client/test/e2e/client.test.ts
@@ -356,9 +356,29 @@ describe('Http Client', () => {
         expect(convoId2).toBe(convoId)
       })
 
-      test('Should be able to reverse map the conversation id to get back the same endpoint', async () => {
+      test('Should fail to map an endpoint with an unknown channel', async () => {
+        await expect(client.mapEndpoint({ ...endpoint, channel: { name: 'yoyo', version: '1.0.0' } })).rejects.toThrow(
+          new Error('Request failed with status code 400')
+        )
+      })
+
+      test('Should fail to map an endpoint with invalid fields', async () => {
+        await expect(client.mapEndpoint({ ...endpoint, identity: null as any })).rejects.toThrow(
+          new Error('Request failed with status code 400')
+        )
+      })
+
+      test('Should be able to list the endpoints of a conversation to get back the same endpoint', async () => {
         const [mappedEndpoint] = await client.listEndpoints(convoId!)
         expect(mappedEndpoint).toEqual(endpoint)
+      })
+
+      test('Should be able to list the endpoints of a conversation that has not endpoints', async () => {
+        const user = await client.createUser()
+        const conversation = await client.createConversation(user.id)
+
+        const endpoints = await client.listEndpoints(conversation.id)
+        expect(endpoints).toEqual([])
       })
     })
   })

--- a/packages/client/test/e2e/client.test.ts
+++ b/packages/client/test/e2e/client.test.ts
@@ -340,4 +340,21 @@ describe('Http Client', () => {
       })
     })
   })
+
+  describe('Endpoints', () => {
+    describe('Map', () => {
+      const endpoint = { channel: { name: 'telegram', version: '1.0.0' }, identity: '*', sender: 'yoyo', thread: 'ya' }
+      let convoId: string | undefined
+
+      test('Should be able to map an endpoint to a conversation id', async () => {
+        convoId = await client.mapEndpoint(endpoint)
+        expect(validateUuid(convoId)).toBeTruthy()
+      })
+
+      test('Should be able to map the endpoint to the same conversation id again', async () => {
+        const convoId2 = await client.mapEndpoint(endpoint)
+        expect(convoId2).toBe(convoId)
+      })
+    })
+  })
 })

--- a/packages/client/test/e2e/client.test.ts
+++ b/packages/client/test/e2e/client.test.ts
@@ -357,7 +357,7 @@ describe('Http Client', () => {
       })
 
       test('Should be able to reverse map the conversation id to get back the same endpoint', async () => {
-        const [mappedEndpoint] = await client.revmapEndpoint(convoId!)
+        const [mappedEndpoint] = await client.listEndpoints(convoId!)
         expect(mappedEndpoint).toEqual(endpoint)
       })
     })

--- a/packages/client/test/e2e/client.test.ts
+++ b/packages/client/test/e2e/client.test.ts
@@ -355,6 +355,11 @@ describe('Http Client', () => {
         const convoId2 = await client.mapEndpoint(endpoint)
         expect(convoId2).toBe(convoId)
       })
+
+      test('Should be able to reverse map the conversation id to get back the same endpoint', async () => {
+        const [mappedEndpoint] = await client.revmapEndpoint(convoId!)
+        expect(mappedEndpoint).toEqual(endpoint)
+      })
     })
   })
 })

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -41,7 +41,7 @@ export class Api {
     this.users = new UserApi(this.app.users)
     this.conversations = new ConversationApi(this.app.users, this.app.conversations)
     this.messages = new MessageApi(this.app.users, this.app.conversations, this.app.messages, this.app.converse)
-    this.mapping = new MappingApi(this.app.channels, this.app.mapping)
+    this.mapping = new MappingApi(this.app.channels, this.app.conversations, this.app.mapping)
 
     this.channels = new ChannelApi(this.root, this.app)
   }

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -9,6 +9,7 @@ import { ChannelApi } from './channels/api'
 import { ClientApi } from './clients/api'
 import { ConversationApi } from './conversations/api'
 import { HealthApi } from './health/api'
+import { MappingApi } from './mapping/api'
 import { MessageApi } from './messages/api'
 import { SyncApi } from './sync/api'
 import { UserApi } from './users/api'
@@ -25,6 +26,7 @@ export class Api {
   private users: UserApi
   private conversations: ConversationApi
   private messages: MessageApi
+  private mapping: MappingApi
   private channels: ChannelApi
 
   constructor(private app: App, private root: Router) {
@@ -39,6 +41,7 @@ export class Api {
     this.users = new UserApi(this.app.users)
     this.conversations = new ConversationApi(this.app.users, this.app.conversations)
     this.messages = new MessageApi(this.app.users, this.app.conversations, this.app.messages, this.app.converse)
+    this.mapping = new MappingApi(this.app.channels, this.app.mapping)
 
     this.channels = new ChannelApi(this.root, this.app)
   }
@@ -67,6 +70,7 @@ export class Api {
     this.users.setup(this.manager)
     this.conversations.setup(this.manager)
     this.messages.setup(this.manager)
+    this.mapping.setup(this.manager)
 
     await this.channels.setup()
 

--- a/packages/server/src/mapping/api.ts
+++ b/packages/server/src/mapping/api.ts
@@ -16,7 +16,7 @@ export class MappingApi {
 
   setup(router: ApiManager) {
     router.post('/endpoints/map', Schema.Api.Map, this.map.bind(this))
-    router.get('/endpoints/conversation/:conversationId', Schema.Api.Revmap, this.revmap.bind(this))
+    router.get('/endpoints/conversation/:conversationId', Schema.Api.Revmap, this.list.bind(this))
   }
 
   async map(req: ClientApiRequest, res: Response) {
@@ -28,7 +28,7 @@ export class MappingApi {
     res.send({ conversationId })
   }
 
-  async revmap(req: ClientApiRequest, res: Response) {
+  async list(req: ClientApiRequest, res: Response) {
     const { conversationId } = req.params
 
     const conversation = await this.conversations.fetch(conversationId)

--- a/packages/server/src/mapping/api.ts
+++ b/packages/server/src/mapping/api.ts
@@ -4,7 +4,7 @@ import { ApiManager } from '../base/api-manager'
 import { ClientApiRequest } from '../base/auth/client'
 import { ChannelService } from '../channels/service'
 import { ConversationService } from '../conversations/service'
-import { Schema } from './schema'
+import { makeMapRequestSchema, Schema } from './schema'
 import { MappingService } from './service'
 
 export class MappingApi {
@@ -15,8 +15,8 @@ export class MappingApi {
   ) {}
 
   setup(router: ApiManager) {
-    router.post('/endpoints/map', Schema.Api.Map, this.map.bind(this))
-    router.get('/endpoints/conversation/:conversationId', Schema.Api.Revmap, this.list.bind(this))
+    router.post('/endpoints/map', makeMapRequestSchema(this.channels.list()), this.map.bind(this))
+    router.get('/endpoints/conversation/:conversationId', Schema.Api.List, this.list.bind(this))
   }
 
   async map(req: ClientApiRequest, res: Response) {

--- a/packages/server/src/mapping/api.ts
+++ b/packages/server/src/mapping/api.ts
@@ -15,10 +15,8 @@ export class MappingApi {
   ) {}
 
   setup(router: ApiManager) {
-    router.post('/endpoints', Schema.Api.Map, this.map.bind(this))
-
-    // TODO: terrible name. To be renamed to something else. Both routes are likely to change name
-    router.post('/endpoints/reverse', Schema.Api.Revmap, this.revmap.bind(this))
+    router.post('/endpoints/map', Schema.Api.Map, this.map.bind(this))
+    router.post('/endpoints/conversation/:conversationId', Schema.Api.Revmap, this.revmap.bind(this))
   }
 
   async map(req: ClientApiRequest, res: Response) {
@@ -31,7 +29,7 @@ export class MappingApi {
   }
 
   async revmap(req: ClientApiRequest, res: Response) {
-    const { conversationId } = req.body
+    const { conversationId } = req.params
 
     const conversation = await this.conversations.fetch(conversationId)
     if (!conversation || conversation.clientId !== req.clientId) {

--- a/packages/server/src/mapping/api.ts
+++ b/packages/server/src/mapping/api.ts
@@ -1,0 +1,24 @@
+import { Endpoint } from '@botpress/messaging-base'
+import { Response } from 'express'
+import { ApiManager } from '../base/api-manager'
+import { ClientApiRequest } from '../base/auth/client'
+import { ChannelService } from '../channels/service'
+import { Schema } from './schema'
+import { MappingService } from './service'
+
+export class MappingApi {
+  constructor(private channels: ChannelService, private mapping: MappingService) {}
+
+  setup(router: ApiManager) {
+    router.post('/endpoints', Schema.Api.Map, this.map.bind(this))
+  }
+
+  async map(req: ClientApiRequest, res: Response) {
+    const endpoint = req.body as Endpoint
+
+    const channel = this.channels.getByNameAndVersion(endpoint.channel.name, endpoint.channel.version)
+    const { conversationId } = await this.mapping.getMapping(req.clientId, channel.meta.id, endpoint)
+
+    res.send({ conversationId })
+  }
+}

--- a/packages/server/src/mapping/api.ts
+++ b/packages/server/src/mapping/api.ts
@@ -16,7 +16,7 @@ export class MappingApi {
 
   setup(router: ApiManager) {
     router.post('/endpoints/map', Schema.Api.Map, this.map.bind(this))
-    router.post('/endpoints/conversation/:conversationId', Schema.Api.Revmap, this.revmap.bind(this))
+    router.get('/endpoints/conversation/:conversationId', Schema.Api.Revmap, this.revmap.bind(this))
   }
 
   async map(req: ClientApiRequest, res: Response) {

--- a/packages/server/src/mapping/schema.ts
+++ b/packages/server/src/mapping/schema.ts
@@ -1,20 +1,27 @@
+import { Channel } from '@botpress/messaging-channels'
 import Joi from 'joi'
 import { ReqSchema } from '../base/schema'
 
-const Api = {
-  Map: ReqSchema({
+export const makeMapRequestSchema = (channels: Channel[]) => {
+  return ReqSchema({
     body: {
-      channel: Joi.object({
-        name: Joi.string().required(),
-        version: Joi.string().required()
-      }).required(),
+      channel: Joi.alternatives(
+        channels.map((x) =>
+          Joi.object({
+            name: Joi.string().valid(x.meta.name).required(),
+            version: Joi.string().valid(x.meta.version).required()
+          })
+        )
+      ).required(),
       identity: Joi.string().required(),
       sender: Joi.string().required(),
       thread: Joi.string().required()
     }
-  }),
+  })
+}
 
-  Revmap: ReqSchema({
+const Api = {
+  List: ReqSchema({
     params: {
       conversationId: Joi.string().guid().required()
     }

--- a/packages/server/src/mapping/schema.ts
+++ b/packages/server/src/mapping/schema.ts
@@ -12,6 +12,12 @@ const Api = {
       sender: Joi.string().required(),
       thread: Joi.string().required()
     }
+  }),
+
+  Revmap: ReqSchema({
+    body: {
+      conversationId: Joi.string().required()
+    }
   })
 }
 

--- a/packages/server/src/mapping/schema.ts
+++ b/packages/server/src/mapping/schema.ts
@@ -15,8 +15,8 @@ const Api = {
   }),
 
   Revmap: ReqSchema({
-    body: {
-      conversationId: Joi.string().required()
+    params: {
+      conversationId: Joi.string().guid().required()
     }
   })
 }

--- a/packages/server/src/mapping/schema.ts
+++ b/packages/server/src/mapping/schema.ts
@@ -1,0 +1,18 @@
+import Joi from 'joi'
+import { ReqSchema } from '../base/schema'
+
+const Api = {
+  Map: ReqSchema({
+    body: {
+      channel: Joi.object({
+        name: Joi.string().required(),
+        version: Joi.string().required()
+      }).required(),
+      identity: Joi.string().required(),
+      sender: Joi.string().required(),
+      thread: Joi.string().required()
+    }
+  })
+}
+
+export const Schema = { Api }

--- a/packages/server/test/security/api.test.ts
+++ b/packages/server/test/security/api.test.ts
@@ -1,4 +1,4 @@
-import { Conversation, Message, SyncRequest, SyncResult, User } from '@botpress/messaging-base'
+import { Conversation, Endpoint, Message, SyncRequest, SyncResult, User } from '@botpress/messaging-base'
 import axios, { AxiosError, AxiosRequestConfig, Method } from 'axios'
 import _ from 'lodash'
 import querystring from 'querystring'
@@ -962,6 +962,44 @@ describe('API', () => {
               clients.first.clientId,
               clients.first.clientToken
             ),
+          (err) => {
+            expect(err.response?.data).toEqual('Not Found')
+            expect(err.response?.status).toEqual(404)
+          }
+        )
+      })
+    })
+  })
+
+  describe('Endpoints', () => {
+    const listEndpoints = async (
+      conversationId: string,
+      clientId?: string,
+      clientToken?: string,
+      config?: AxiosRequestConfig
+    ) => {
+      const res = await http(clientId, clientToken).get<Endpoint[]>(
+        `/api/v1/endpoints/conversation/${conversationId}`,
+        config
+      )
+
+      return res.data
+    }
+
+    describe('List', () => {
+      test('Should not be able to list endpoints without being authenticated', async () => {
+        await shouldFail(
+          async () => listEndpoints(clients.first.conversationId),
+          (err) => {
+            expect(err.response?.data).toEqual('Unauthorized')
+            expect(err.response?.status).toEqual(401)
+          }
+        )
+      })
+
+      test('Should not be able to list endpoints of another client', async () => {
+        await shouldFail(
+          async () => listEndpoints(clients.second.conversationId, clients.first.clientId, clients.first.clientToken),
           (err) => {
             expect(err.response?.data).toEqual('Not Found')
             expect(err.response?.status).toEqual(404)


### PR DESCRIPTION
Adds two new routes that make up the "endpoint" API. One route `/endpoints/map` to get a conversationId from an endpoint, and the route `/endpoints/conversation/:conversationId` to list the endpoints associated to a conversation (since a conversation can be present on more than one channel)

TODO: add documentation

Closes DEV-2339