### PR TITLE
chore(webchat): bump to 0.2.0

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-components",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.tsx",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/webchat-inject",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "AGPL-3.0",
   "scripts": {
     "build": "yarn && yarn run -T parcel build src/index.html src/inject.js --public-url ./",
@@ -20,7 +20,7 @@
     "@types/react-dom": "^17.0.11"
   },
   "dependencies": {
-    "@botpress/webchat": "0.1.0",
+    "@botpress/webchat": "0.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/packages/webchat/package.json
+++ b/packages/webchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/webchat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.tsx",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.23.1",
-    "@botpress/messaging-components": "0.1.0",
+    "@botpress/messaging-components": "0.2.0",
     "@botpress/messaging-socket": "1.1.0",
     "@formatjs/intl-pluralrules": "^4.1.6",
     "@formatjs/intl-utils": "^3.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,7 +2189,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/messaging-components@0.1.0, @botpress/messaging-components@workspace:packages/components":
+"@botpress/messaging-components@0.2.0, @botpress/messaging-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@botpress/messaging-components@workspace:packages/components"
   dependencies:
@@ -2393,7 +2393,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@botpress/webchat-inject@workspace:packages/inject"
   dependencies:
-    "@botpress/webchat": 0.1.0
+    "@botpress/webchat": 0.2.0
     "@parcel/config-default": ^2.2.1
     "@parcel/reporter-bundle-analyzer": 2.2.1
     "@parcel/transformer-typescript-tsc": ^2.2.1
@@ -2404,12 +2404,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/webchat@*, @botpress/webchat@0.1.0, @botpress/webchat@workspace:packages/webchat":
+"@botpress/webchat@*, @botpress/webchat@0.2.0, @botpress/webchat@workspace:packages/webchat":
   version: 0.0.0-use.local
   resolution: "@botpress/webchat@workspace:packages/webchat"
   dependencies:
     "@blueprintjs/core": ^3.23.1
-    "@botpress/messaging-components": 0.1.0
+    "@botpress/messaging-components": 0.2.0
     "@botpress/messaging-socket": 1.1.0
     "@formatjs/intl-pluralrules": ^4.1.6
     "@formatjs/intl-utils": ^3.8.4


### PR DESCRIPTION
Bumps and published all packages related to webchat to version 0.2.0. Also updated the cdn. We can now see what version of the webchat is deployed at : https://cdn.botpress.dev/webchat/v0/version.json (version should match versions deployed on npm)