### PR TITLE
chore(ci): use nvmrc version instead of hard coded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install Dependencies
         run: |
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install Dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Git Unshallow

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -39,7 +39,7 @@ jobs:
             postgres:latest
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -74,7 +74,7 @@ jobs:
             postgres:latest
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -109,7 +109,7 @@ jobs:
             postgres:latest
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -144,7 +144,7 @@ jobs:
             postgres:latest
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.13.2'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |


### PR DESCRIPTION
This PR updates the Github Actions to use the version of NodeJS specified in the .nvmrc file instead of a hard-coded version.