### PR TITLE
fix(channels): logging incorrect webhook for channel legacy

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@botpress/messaging-base": "*",
     "@botpress/messaging-channels": "*",
-    "@botpress/messaging-channels-legacy": "npm:@botpress/messaging-channels@0.1.3",
+    "@botpress/messaging-channels-legacy": "npm:@botpress/messaging-channels@0.1.4",
     "@botpress/messaging-engine": "*",
     "@sentry/node": "^6.17.3",
     "axios": "^0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,9 +2116,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/messaging-channels-legacy@npm:@botpress/messaging-channels@0.1.3":
-  version: 0.1.3
-  resolution: "@botpress/messaging-channels@npm:0.1.3"
+"@botpress/messaging-channels-legacy@npm:@botpress/messaging-channels@0.1.4":
+  version: 0.1.4
+  resolution: "@botpress/messaging-channels@npm:0.1.4"
   dependencies:
     "@slack/events-api": ^2.3.2
     "@slack/interactive-messages": ^1.5.0
@@ -2139,7 +2139,7 @@ __metadata:
     twilio: ^3.67.0
     uuid: ^8.3.2
     yn: ^4.0.0
-  checksum: 04c89f927e252c2d718ea81af0e7d3dc914d071224136dd9093d2454bec1a9f884a80a2c3a7fe3ee7890d257ea30e49679fab69a223209c8442bb8267214bc6b
+  checksum: ea431ca55eb767898f98993f7681853aaf131798beddb3e7de23d7bc7935587d712f157a01be47c93e2f452e0bef7043bc7d641d74a59e5bf2c7dd00590c88f1
   languageName: node
   linkType: hard
 
@@ -2286,7 +2286,7 @@ __metadata:
   dependencies:
     "@botpress/messaging-base": "*"
     "@botpress/messaging-channels": "*"
-    "@botpress/messaging-channels-legacy": "npm:@botpress/messaging-channels@0.1.3"
+    "@botpress/messaging-channels-legacy": "npm:@botpress/messaging-channels@0.1.4"
     "@botpress/messaging-engine": "*"
     "@sentry/node": ^6.17.3
     "@types/cli-color": ^2.0.2


### PR DESCRIPTION
Fixes a problem where channels would print their webhooks with the name in it twice (so for example twilio would print externalUrl/webhooks/botId/twilio/twilio)

Commit in v1 https://github.com/botpress/messaging/commit/030a8a3699f3e024db9b5d95519de7d2cea22fa2