### PR TITLE
chore(webchat): remove the concept of reference

### DIFF
--- a/packages/webchat/src/core/api.tsx
+++ b/packages/webchat/src/core/api.tsx
@@ -158,19 +158,6 @@ export default class WebchatApi {
     }
   }
 
-  async setReference(reference: string, conversationId: uuid): Promise<void> {
-    // TODO: this can't work. We don't have a reference route
-    try {
-      return this.axios.post(
-        '/conversations/reference',
-        { ...this.baseUserPayload, conversationId, reference },
-        this.axiosConfig
-      )
-    } catch (err) {
-      await this.handleApiError(err)
-    }
-  }
-
   // TODO: Remove this once we stop making HTTP calls
   handleApiError = async (error: any) => {
     // @deprecated 11.9 (replace with proper error management)

--- a/packages/webchat/src/main.tsx
+++ b/packages/webchat/src/main.tsx
@@ -91,11 +91,6 @@ class Web extends React.Component<MainProps> {
       this.postMessageToParent('setWidth', this.config.containerWidth)
     }
 
-    // TODO: properly implement of deprecate this feature
-    //if (this.config.reference) {
-    //  await this.props.setReference!()
-    //}
-
     // TODO: replace this by frontend configuration
     // await this.props.fetchBotInfo!()
 
@@ -118,11 +113,10 @@ class Web extends React.Component<MainProps> {
         return options
       }
     }
-    const { options, ref } = queryString.parse(location.search)
+    const { options } = queryString.parse(location.search)
     const { config } = JSON.parse(decodeIfRequired((options as string) || '{}'))
 
     const userConfig: Config = Object.assign({}, constants.DEFAULT_CONFIG, this.props.config, config)
-    userConfig.reference = config?.ref || ref
 
     this.props.updateConfig!(userConfig)
 
@@ -389,7 +383,6 @@ export default inject(({ store }: { store: RootStore }) => ({
   setUserId: store.setUserId,
   updateTyping: store.updateTyping,
   sendMessage: store.sendMessage,
-  setReference: store.setReference,
   updateBotUILanguage: store.updateBotUILanguage,
   isWebchatReady: store.view.isWebchatReady,
   showWidgetButton: store.view.showWidgetButton,
@@ -422,7 +415,6 @@ type MainProps = { store: RootStore } & WrappedComponentProps &
     | 'sendData'
     | 'intl'
     | 'updateTyping'
-    | 'setReference'
     | 'updateBotUILanguage'
     | 'hideChat'
     | 'showChat'

--- a/packages/webchat/src/store/index.ts
+++ b/packages/webchat/src/store/index.ts
@@ -315,11 +315,6 @@ class RootStore {
   }
 
   @action.bound
-  async setReference(): Promise<void> {
-    return this.api.setReference(this.config.reference!, this.currentConversationId)
-  }
-
-  @action.bound
   resetConversation() {
     this.currentConversation = undefined!
   }

--- a/packages/webchat/src/typings.ts
+++ b/packages/webchat/src/typings.ts
@@ -210,8 +210,6 @@ export interface Config {
   enablePersistHistory: boolean
   /** Experimental: expose the store to the parent frame for more control on the webchat's behavior */
   exposeStore: boolean
-  /** Reference ensures that a specific value and its signature are valid */
-  reference?: string
   /** If true, Websocket is created when the Webchat is opened. Bot cannot be proactive. */
   lazySocket?: boolean
   /** If true, chat will no longer play the notification sound for new messages. */


### PR DESCRIPTION
This PR removes the already broken concept of conversation references. As this was to address security concerns but isn't required anymore with the messaging socket implementation and security measures we have.

Closes DEV-2305