### PR TITLE
chore(ci_cd): add tmp invalidation step when uploading webchat

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -3,12 +3,11 @@ on:
   push:
     branches:
       - master
-  # TODO: Uncomment this once we know the action is working as expected
-  #paths:
-  #  - 'packages/inject/**'
-  #  - 'packages/components/**'
-  #  - 'packages/webchat/**'
-  #  - 'packages/socket/**'
+    paths:
+      - 'packages/inject/**'
+      - 'packages/components/**'
+      - 'packages/webchat/**'
+      - 'packages/socket/**'
 
 permissions:
   id-token: write
@@ -41,4 +40,7 @@ jobs:
           role-session-name: messaging_ci_upload_webchat
           aws-region: us-east-1
       - name: Upload Webchat to S3 bucket
-        run: aws s3 sync ./dist s3://${{ secrets.AWS_WEBCHAT_BUCKET_NAME }}/v0 # TODO: Change the version (for test purpose)
+        run: |
+          # TODO: Change the version (for test purpose)
+          aws s3 sync --delete ./dist s3://${{ secrets.AWS_WEBCHAT_BUCKET_NAME }}/v0
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_WEBCHAT_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
This PR adds a temporary invalidation step to the action that uploads the webchat so that we are sure the CDN always provides the latest version of the webchat bundle. I also added the [`--delete`](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html) argument to the upload call so that we delete old files if needed. Finally, we only deploy the webchat if there were changes in any files related to it.