### PR TITLE
fix(sockets): fix socket unable to send error message crashing server

### DIFF
--- a/packages/server/src/socket/manager.ts
+++ b/packages/server/src/socket/manager.ts
@@ -136,11 +136,11 @@ export class SocketManager {
   }
 
   async setupSocket(socket: Socket.Socket) {
-    socket.on('message', async (data) => {
-      await this.handleSocketMessage(socket, data)
+    socket.on('message', (data) => {
+      void this.handleSocketMessage(socket, data)
     })
-    socket.on('disconnect', async () => {
-      await this.handleSocketDisconnect(socket)
+    socket.on('disconnect', () => {
+      void this.handleSocketDisconnect(socket)
     })
   }
 
@@ -156,7 +156,11 @@ export class SocketManager {
     } catch (e) {
       this.logger.error(e, 'An error occured receiving a socket message', message)
 
-      return this.reply(socket, message, { error: true, message: 'an error occurred' })
+      try {
+        return this.reply(socket, message, { error: true, message: 'an error occurred' })
+      } catch (e) {
+        this.logger.error(e, 'An error occured sending an error message to the socket')
+      }
     }
   }
 


### PR DESCRIPTION
Fixes bug reported here https://botpresshq.slack.com/archives/C02AFENA9C5/p1646837902625429

The code for socket message handling had a try catch, but the code located in the catch could also throw, so I added a try catch there also.

Closes DEV-2425