### PR TITLE
feat(components): added location component

### DIFF
--- a/misc/api.rest
+++ b/misc/api.rest
@@ -182,6 +182,24 @@ Content-Type: application/json
   }
 }
 
+### Send Location
+POST {{baseUrl}}/api/v1/messages
+Authorization: Bearer {{authToken}}
+x-bp-messaging-client-id: {{clientId}}
+x-bp-messaging-client-token: {{clientToken}}
+Content-Type: application/json
+
+{
+  "conversationId": "{{convoId}}",
+  "payload": {
+    "type": "location",
+    "latitude": -25.363,
+    "longitude": 130.044,
+    "title": "Rocks",
+    "address": "Uluru (Ayers Rock)"
+  }
+}
+
 ### Send Choices
 POST {{baseUrl}}/api/v1/messages
 Authorization: Bearer {{authToken}}
@@ -218,7 +236,7 @@ Content-Type: application/json
       { "label": "Yay", "value": "YES" },
       { "label": "Nay", "value": "NO" }
     ],
-    "displayInKeyboard": false
+    "displayInKeyboard": true
   }
 }
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,6 +16,7 @@
     "dist"
   ],
   "dependencies": {
+    "@googlemaps/react-wrapper": "^1.1.26",
     "html-truncate": "^1.2.2",
     "mime": "^2.5.2",
     "react-intl": "^3.12.1",
@@ -39,6 +40,7 @@
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "@types/dom-mediacapture-record": "^1.0.11",
+    "@types/google.maps": "^3.48.2",
     "@types/html-truncate": "^1.2.2",
     "@types/jest": "^27.4.0",
     "@types/mime": "^2.0.3",
@@ -55,6 +57,7 @@
     "react-test-renderer": "^17.0.2"
   },
   "peerDependencies": {
+    "@googlemaps/react-wrapper": "^1.1.26",
     "html-truncate": "^1.2.2",
     "mime": "^2.5.2",
     "prop-types": "^15.7.2",

--- a/packages/components/src/css/botpress-default.css
+++ b/packages/components/src/css/botpress-default.css
@@ -405,6 +405,11 @@ body {
   border-bottom-left-radius: inherit;
 }
 
+.bpw-bubble-location #map {
+  width: 300px;
+  height: 300px;
+}
+
 .bpw-chat-bubble p {
   margin: 0;
 }

--- a/packages/components/src/renderer/index.tsx
+++ b/packages/components/src/renderer/index.tsx
@@ -6,6 +6,7 @@ import { QuickReply, SingleChoice } from './choice'
 import { Custom } from './custom'
 import { Dropdown } from './dropdown'
 import { Video, Audio, Image, File } from './file'
+import { Location } from './location'
 import { LoginPrompt } from './login'
 import { Text } from './text'
 import { TypingIndicator } from './typing'
@@ -19,7 +20,7 @@ export const defaultTypesRenderers = {
   carousel: Carousel,
   card: Card,
   // Currently unsupported
-  // location: () => null,
+  location: Location,
   file: File,
   video: Video,
   audio: Audio,
@@ -91,6 +92,7 @@ export {
   defaultRenderer as default,
   Carousel,
   Card,
+  Location,
   Image,
   File,
   Video,

--- a/packages/components/src/renderer/location.tsx
+++ b/packages/components/src/renderer/location.tsx
@@ -2,7 +2,12 @@ import { Status, Wrapper } from '@googlemaps/react-wrapper'
 import React, { useEffect, useRef } from 'react'
 import { MessageTypeHandlerProps } from '../typings'
 
-export const MapContainer: React.FC<MessageTypeHandlerProps<'location'>> = ({ latitude, longitude, address }) => {
+export const MapContainer: React.FC<MessageTypeHandlerProps<'location'>> = ({
+  latitude,
+  longitude,
+  address,
+  title
+}) => {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -28,28 +33,44 @@ export const MapContainer: React.FC<MessageTypeHandlerProps<'location'>> = ({ la
     }
   })
 
-  return <div ref={ref} id="map" />
+  return (
+    <>
+      <p>{title}</p>
+      <p>{address}</p>
+      <div ref={ref} id="map" />
+    </>
+  )
 }
 
-const Fallback = ({ latitude, longitude }: { latitude: number; longitude: number }): React.ReactElement => {
+const Fallback = ({
+  latitude,
+  longitude,
+  address,
+  title
+}: Pick<MessageTypeHandlerProps<'location'>, 'latitude' | 'longitude' | 'address' | 'title'>): React.ReactElement => {
   const link = `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`
   return (
-    <p>
-      Location:&nbsp;
-      <a href={link} target="_blank">
-        {link}
+    <div>
+      <p>{title}</p>
+      <a href={link} target="_blank" rel="noopener">
+        {address}
       </a>
-    </p>
+    </div>
   )
 }
 
 const render =
-  (latitude: number, longitude: number) =>
+  ({
+    latitude,
+    longitude,
+    address,
+    title
+  }: Pick<MessageTypeHandlerProps<'location'>, 'latitude' | 'longitude' | 'address' | 'title'>) =>
   (status: Status): React.ReactElement => {
     if (status === Status.LOADING) {
       return <div>Loading...</div>
     } else if (status === Status.FAILURE) {
-      return <Fallback latitude={latitude} longitude={longitude} />
+      return <Fallback latitude={latitude} longitude={longitude} address={address} title={title} />
     } else {
       return <></>
     }
@@ -65,7 +86,7 @@ export const Location: React.FC<MessageTypeHandlerProps<'location'>> = ({
 }) => {
   if (config.googleMapsAPIKey) {
     return (
-      <Wrapper apiKey={config.googleMapsAPIKey} render={render(latitude, longitude)}>
+      <Wrapper apiKey={config.googleMapsAPIKey} render={render({ latitude, longitude, address, title })}>
         <MapContainer
           latitude={latitude}
           longitude={longitude}
@@ -77,6 +98,6 @@ export const Location: React.FC<MessageTypeHandlerProps<'location'>> = ({
       </Wrapper>
     )
   } else {
-    return <Fallback latitude={latitude} longitude={longitude} />
+    return <Fallback latitude={latitude} longitude={longitude} address={address} title={title} />
   }
 }

--- a/packages/components/src/renderer/location.tsx
+++ b/packages/components/src/renderer/location.tsx
@@ -1,0 +1,82 @@
+import { Status, Wrapper } from '@googlemaps/react-wrapper'
+import React, { useEffect, useRef } from 'react'
+import { MessageTypeHandlerProps } from '../typings'
+
+export const MapContainer: React.FC<MessageTypeHandlerProps<'location'>> = ({ latitude, longitude, address }) => {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!ref.current) {
+      return
+    }
+
+    const position = { lat: latitude, lng: longitude }
+
+    const map = new window.google.maps.Map(ref.current, {
+      center: position,
+      zoom: 14
+    })
+
+    const marker = new google.maps.Marker({
+      position,
+      map,
+      title: address
+    })
+
+    return () => {
+      marker.setMap(null)
+    }
+  })
+
+  return <div ref={ref} id="map" />
+}
+
+const Fallback = ({ latitude, longitude }: { latitude: number; longitude: number }): React.ReactElement => {
+  const link = `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`
+  return (
+    <p>
+      Location:&nbsp;
+      <a href={link} target="_blank">
+        {link}
+      </a>
+    </p>
+  )
+}
+
+const render =
+  (latitude: number, longitude: number) =>
+  (status: Status): React.ReactElement => {
+    if (status === Status.LOADING) {
+      return <div>Loading...</div>
+    } else if (status === Status.FAILURE) {
+      return <Fallback latitude={latitude} longitude={longitude} />
+    } else {
+      return <></>
+    }
+  }
+
+export const Location: React.FC<MessageTypeHandlerProps<'location'>> = ({
+  latitude,
+  longitude,
+  address,
+  title,
+  type,
+  config
+}) => {
+  if (config.googleMapsAPIKey) {
+    return (
+      <Wrapper apiKey={config.googleMapsAPIKey} render={render(latitude, longitude)}>
+        <MapContainer
+          latitude={latitude}
+          longitude={longitude}
+          address={address}
+          title={title}
+          type={type}
+          config={config}
+        />
+      </Wrapper>
+    )
+  } else {
+    return <Fallback latitude={latitude} longitude={longitude} />
+  }
+}

--- a/packages/components/src/typings.ts
+++ b/packages/components/src/typings.ts
@@ -26,6 +26,7 @@ export interface MessageConfig {
   bp?: StudioConnector
   store?: LiteStore
   shouldPlay?: boolean // used for voice message only
+  googleMapsAPIKey?: string
   onSendData: (data: any) => Promise<void>
   onFileUpload: FileUploadHandler
   onAudioEnded?: (this: HTMLMediaElement, ev: HTMLMediaElementEventMap['ended']) => void

--- a/packages/webchat/src/components/messages/Message.tsx
+++ b/packages/webchat/src/components/messages/Message.tsx
@@ -52,7 +52,8 @@ class Message extends Component<MessageProps> {
           shouldPlay: this.props.shouldPlay,
           intl: this.props.store!.intl,
           escapeHTML: true,
-          showTimestamp: this.props.store!.config.showTimestamp!
+          showTimestamp: this.props.store!.config.showTimestamp!,
+          googleMapsAPIKey: this.props.store!.config.googleMapsAPIKey
         }}
       />
     )

--- a/packages/webchat/src/typings.ts
+++ b/packages/webchat/src/typings.ts
@@ -288,9 +288,15 @@ export interface Config {
   chatId?: string
   /**
    * CSS class to be applied to iframe
-   * @default '''
+   * @default ''
    */
   className?: string
+  /**
+   * Google Maps API Key required to display the map.
+   * Will display a link to Google Maps otherwise
+   * @default ''
+   */
+  googleMapsAPIKey?: string
 }
 
 export interface BotDetails {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,6 +2207,7 @@ __metadata:
   resolution: "@botpress/messaging-components@workspace:packages/components"
   dependencies:
     "@babel/core": ^7.16.12
+    "@googlemaps/react-wrapper": ^1.1.26
     "@storybook/addon-essentials": ^6.4.17
     "@storybook/addon-links": ^6.4.17
     "@storybook/addon-measure": ^6.4.17
@@ -2219,6 +2220,7 @@ __metadata:
     "@testing-library/react": ^12.1.2
     "@testing-library/user-event": ^13.5.0
     "@types/dom-mediacapture-record": ^1.0.11
+    "@types/google.maps": ^3.48.2
     "@types/html-truncate": ^1.2.2
     "@types/jest": ^27.4.0
     "@types/mime": ^2.0.3
@@ -2242,6 +2244,7 @@ __metadata:
     react-text-format: ^2.0.28
     snarkdown: ^2.0.0
   peerDependencies:
+    "@googlemaps/react-wrapper": ^1.1.26
     html-truncate: ^1.2.2
     mime: ^2.5.2
     prop-types: ^15.7.2
@@ -2815,6 +2818,26 @@ __metadata:
   version: 1.1.2
   resolution: "@gar/promisify@npm:1.1.2"
   checksum: d05081e0887a49c178b75ee3067bd6ee086f73c154d121b854fb2e044e8a89cb1cbb6de3a0dd93a519b80f0531fda68b099dd7256205f7fbb3490324342f2217
+  languageName: node
+  linkType: hard
+
+"@googlemaps/js-api-loader@npm:^1.13.2":
+  version: 1.13.8
+  resolution: "@googlemaps/js-api-loader@npm:1.13.8"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+  checksum: d47cce32bb842448b8d9a594407b2693bc4a605729b5c1010568023dff4b471ba74faa03f0b50283126b5a6ad44b3a67b48bda9fcbe459c0b9d9343cfc221c52
+  languageName: node
+  linkType: hard
+
+"@googlemaps/react-wrapper@npm:^1.1.26":
+  version: 1.1.26
+  resolution: "@googlemaps/react-wrapper@npm:1.1.26"
+  dependencies:
+    "@googlemaps/js-api-loader": ^1.13.2
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 4be3cea5d54727ce560592fd9672ceb0dc567db6c2834d4ca5972e354f0cd0444d74bab0a20d352946e6d568b6a56b1289efbd4fe429d8b187d99e1f72dfd2b6
   languageName: node
   linkType: hard
 
@@ -6011,6 +6034,13 @@ __metadata:
     "@types/minimatch": "*"
     "@types/node": "*"
   checksum: 6ae717fedfdfdad25f3d5a568323926c64f52ef35897bcac8aca8e19bc50c0bd84630bbd063e5d52078b2137d8e7d3c26eabebd1a2f03ff350fff8a91e79fc19
+  languageName: node
+  linkType: hard
+
+"@types/google.maps@npm:^3.48.2":
+  version: 3.48.2
+  resolution: "@types/google.maps@npm:3.48.2"
+  checksum: 2fb6fe753485a9183f46a7e9a39bba89862487563208fd2b4b90ef5fcca521f2678aedb3cd520956b8a90d2d76c6c46d45d52c94301fdef182b938ce2d6193ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the location component and enables its support on the webchat.

It requires a Google Maps API Key to be set in the webchat config: https://developers.google.com/maps/documentation/javascript/get-api-key

![Screenshot from 2022-03-10 17-47-44](https://user-images.githubusercontent.com/9640576/157767955-8a4cb380-eb75-4668-a08d-de8cacfebb13.png)

**api.rest** 

```
### Send Location
POST {{baseUrl}}/api/v1/messages
Authorization: Bearer {{authToken}}
x-bp-messaging-client-id: {{clientId}}
x-bp-messaging-client-token: {{clientToken}}
Content-Type: application/json

{
  "conversationId": "{{convoId}}",
  "payload": {
    "type": "location",
    "latitude": -25.363,
    "longitude": 130.044,
    "title": "",
    "address": "Uluru (Ayers Rock)"
  }
}
```  