### PR TITLE
chore(ci_cd): added action to create release

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,40 @@
+name: Create Release Pull Request
+on: [workflow_dispatch]
+
+jobs:
+  create_release_pull_request:
+    name: Create Release Pull Request
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Get version
+        id: get_version
+        run: |
+          echo ::set-output name=new_version::$(node -p "require('./package.json').version")
+
+      - name: Get Release Details
+        id: release_details
+        uses: botpress/gh-actions/get_release_details@next
+
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOTPRESS_BOT_APP_ID }}
+          private_key: ${{ secrets.BOTPRESS_BOT_APP_PRIVATE_KEY }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        id: pull_request
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'chore(server): release v${{ steps.get_version.outputs.new_version }}'
+          commit-message: 'chore(server): release v${{ steps.get_version.outputs.new_version }}'
+          branch: 'release/v${{ steps.get_version.outputs.new_version }}'
+          body: ${{ steps.release_details.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   release_bin:
-    if: startsWith(github.event.head_commit.message, 'release/v') == true
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(server): release v') == true }}"
     name: Release Binaries
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   release_bin:
+    if: startsWith(github.event.head_commit.message, 'release/v') == true
     name: Release Binaries
     runs-on: ubuntu-latest
     steps:
@@ -16,16 +17,13 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      - name: Git Unshallow
-        run: git fetch --prune --unshallow
-
       - name: Fetch Node Packages
         run: |
           yarn --immutable
 
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@v1
+        uses: botpress/gh-actions/get_release_details@next
 
       - name: Display Release Details
         id: changelog
@@ -36,13 +34,11 @@ jobs:
           echo "Latest Tag: ${{ steps.release_details.outputs.latest_tag }}"
 
       - name: Build and Package
-        if: ${{ steps.release_details.outputs.is_new_release == 'true' }}
         run: |
           yarn build
           yarn package
 
       - name: Release
-        if: ${{ steps.release_details.outputs.is_new_release == 'true' }}
         uses: softprops/action-gh-release@v1
         with:
           files: ./bin/messaging-v*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Botpress messaging repo",
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-server",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
This PR adds an action ("Create Release Pull Request") whose task is to automate the creation of the release PR. It also allows us to bump the version of the root package.json while working in the next version without automatically releasing a new binary. 

Also closes DEV-2233