### PR TITLE
chore(ci_cd): use gh-actions v2

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@next
+        uses: botpress/gh-actions/get_release_details@v2
 
       - uses: tibdex/github-app-token@v1
         id: generate-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@next
+        uses: botpress/gh-actions/get_release_details@v2
 
       - name: Display Release Details
         id: changelog


### PR DESCRIPTION
This PR updates the actions from `gh-actions` to its latest version v2.

Note: next was simply merged into v2