### PR TITLE
fix(messenger): remove flaky typing off event

### DIFF
--- a/packages/channels/src/messenger/senders/typing.ts
+++ b/packages/channels/src/messenger/senders/typing.ts
@@ -5,8 +5,4 @@ export class MessengerTypingSender extends TypingSender {
   async sendIndicator(context: MessengerContext) {
     await context.stream.sendAction(context.scope, context, 'typing_on')
   }
-
-  async stopIndicator(context: MessengerContext) {
-    await context.stream.sendAction(context.scope, context, 'typing_off')
-  }
 }


### PR DESCRIPTION
This PR fixes an issue with messenger when the typing indicates would display wierdly

**Before**

https://user-images.githubusercontent.com/9640576/159575117-45cd1b8d-d301-4453-9b07-6a5d504b7429.mp4



**After**

https://user-images.githubusercontent.com/9640576/159574896-7b1bed39-563f-4640-9da7-07d4765d3304.mp4

