### PR TITLE
chore(tests): add migration cli tests

### DIFF
--- a/packages/server/test/migration/global-diff.test.ts
+++ b/packages/server/test/migration/global-diff.test.ts
@@ -1,3 +1,5 @@
+import portfinder from 'portfinder'
+
 import { compareDatabases } from './utils/diff'
 import { startMessagingServer } from './utils/server'
 
@@ -9,13 +11,14 @@ describe('Global Diff', () => {
   test(
     'Starts Messaging with the latest database schema',
     async () => {
+      const port = await portfinder.getPortPromise()
       await startMessagingServer(
         {
           command: 'yarn dev',
           launchTimeout: TIMEOUT,
           protocol: 'http',
           host: '127.0.0.1',
-          port: 3100,
+          port,
           path: 'status',
           usedPortAction: 'error'
         },

--- a/packages/server/test/migration/migration-cli.test.ts
+++ b/packages/server/test/migration/migration-cli.test.ts
@@ -1,0 +1,218 @@
+import { Knex } from 'knex'
+import portfinder from 'portfinder'
+
+import { setupConnection } from './utils/database'
+import { decrement, increment } from './utils/semver'
+import { startMessagingServer } from './utils/server'
+
+const pkg = require('../../package.json')
+
+const CLI_MIGRATIONS = 'cli_migs'
+const TIMEOUT = 30000
+
+describe('Migration CLI', () => {
+  let conn: Knex
+
+  beforeAll(() => {
+    conn = setupConnection(CLI_MIGRATIONS).conn
+  })
+
+  afterAll(async () => {
+    await conn.destroy()
+  })
+
+  const getLatestMetaVersion = async (): Promise<string | undefined> => {
+    try {
+      const meta = await conn('msg_meta').orderBy('time', 'desc').first()
+
+      if (meta) {
+        const data = JSON.parse(meta.data)
+
+        return data.version
+      }
+    } catch {}
+  }
+
+  test(
+    'Should apply no migration when in dry-run',
+    async () => {
+      await startMessagingServer(
+        {
+          command: 'yarn dev migrate up --dry',
+          launchTimeout: TIMEOUT
+        },
+        CLI_MIGRATIONS
+      )
+
+      expect(await getLatestMetaVersion()).toBeUndefined()
+    },
+    TIMEOUT
+  )
+
+  test(
+    'Should be able to auto migrate to the latest version',
+    async () => {
+      const current = pkg.version
+      const port = await portfinder.getPortPromise()
+
+      await startMessagingServer(
+        {
+          command: 'yarn dev --auto-migrate',
+          launchTimeout: TIMEOUT,
+          protocol: 'http',
+          host: '127.0.0.1',
+          port,
+          path: 'status',
+          usedPortAction: 'error'
+        },
+        CLI_MIGRATIONS
+      )
+
+      expect(await getLatestMetaVersion()).toEqual(current)
+    },
+    TIMEOUT
+  )
+
+  test(
+    'Should be able to run all migrations at once',
+    async () => {
+      const target = '0.0.0'
+
+      await startMessagingServer(
+        {
+          command: `yarn dev migrate down --target ${target}`,
+          launchTimeout: TIMEOUT
+        },
+        CLI_MIGRATIONS
+      )
+
+      expect(await getLatestMetaVersion()).toBeUndefined()
+
+      await startMessagingServer(
+        {
+          command: 'yarn dev migrate up',
+          launchTimeout: TIMEOUT
+        },
+        CLI_MIGRATIONS
+      )
+
+      expect(await getLatestMetaVersion()).toEqual(pkg.version)
+    },
+    TIMEOUT * 2
+  )
+
+  test(
+    'Should be able to migrate down to a given target',
+    async () => {
+      const target = decrement(pkg.version, 'minor')
+
+      await startMessagingServer(
+        {
+          command: `yarn dev migrate down --target ${target}`,
+          launchTimeout: TIMEOUT
+        },
+        CLI_MIGRATIONS
+      )
+
+      expect(await getLatestMetaVersion()).toEqual(target)
+    },
+    TIMEOUT
+  )
+
+  test(
+    'Should be able to migrate up to a given target',
+    async () => {
+      const target = pkg.version
+
+      await startMessagingServer(
+        {
+          command: `yarn dev migrate up --target ${target}`,
+          launchTimeout: TIMEOUT
+        },
+        CLI_MIGRATIONS
+      )
+
+      expect(await getLatestMetaVersion()).toEqual(target)
+    },
+    TIMEOUT
+  )
+
+  test(
+    'Should do nothing if migrate down has no target',
+    async () => {
+      await startMessagingServer(
+        {
+          command: 'yarn dev migrate down',
+          launchTimeout: TIMEOUT
+        },
+        CLI_MIGRATIONS
+      )
+
+      expect(await getLatestMetaVersion()).toEqual(pkg.version)
+    },
+    TIMEOUT
+  )
+
+  test(
+    'Should throw an error if migrate down has a target higher than the current version',
+    async () => {
+      const current = pkg.version
+      const target = increment(pkg.version)
+
+      await expect(
+        startMessagingServer(
+          {
+            command: `yarn dev migrate down --target ${target}`,
+            launchTimeout: TIMEOUT
+          },
+          CLI_MIGRATIONS
+        )
+      ).rejects.toThrow(
+        ` Invalid migration parameters: down migration cannot target a version (${target}) higher than the current server version (${current}).`
+      )
+    },
+    TIMEOUT
+  )
+
+  test(
+    'Should throw an error if migrate up has a target lower than the current version',
+    async () => {
+      const current = pkg.version
+      const target = decrement(pkg.version)
+
+      await expect(
+        startMessagingServer(
+          {
+            command: `yarn dev migrate up --target ${target}`,
+            launchTimeout: TIMEOUT
+          },
+          CLI_MIGRATIONS
+        )
+      ).rejects.toThrow(
+        ` Invalid migration parameters: up migration cannot target a version (${target}) lower than the current server version (${current}).`
+      )
+    },
+    TIMEOUT
+  )
+
+  test(
+    'Should throw an error if migrate up has a target higher than the application version',
+    async () => {
+      const current = pkg.version
+      const target = increment(pkg.version)
+
+      await expect(
+        startMessagingServer(
+          {
+            command: `yarn dev migrate up --target ${target}`,
+            launchTimeout: TIMEOUT
+          },
+          CLI_MIGRATIONS
+        )
+      ).rejects.toThrow(
+        ` Invalid migration parameters: up migration cannot target a version (${target}) higher than the application version (${current}).`
+      )
+    },
+    TIMEOUT
+  )
+})

--- a/packages/server/test/migration/migration-cli.test.ts
+++ b/packages/server/test/migration/migration-cli.test.ts
@@ -215,4 +215,22 @@ describe('Migration CLI', () => {
     },
     TIMEOUT
   )
+
+  test(
+    'Should throw an error if target is invalid',
+    async () => {
+      const target = 'invalid_target'
+
+      await expect(
+        startMessagingServer(
+          {
+            command: `yarn dev migrate up --target ${target}`,
+            launchTimeout: TIMEOUT
+          },
+          CLI_MIGRATIONS
+        )
+      ).rejects.toThrow(` Error occurred starting server. TypeError: Invalid Version: ${target}`)
+    },
+    TIMEOUT
+  )
 })

--- a/packages/server/test/migration/migrations-diff.test.ts
+++ b/packages/server/test/migration/migrations-diff.test.ts
@@ -1,7 +1,7 @@
 import { Migrations } from '../../src/migrations'
 
 import { compareDatabases } from './utils/diff'
-import { decrement } from './utils/semver-decrement'
+import { decrement } from './utils/semver'
 import { startMessagingServer } from './utils/server'
 
 const TIMEOUT = 30000

--- a/packages/server/test/migration/utils/semver.ts
+++ b/packages/server/test/migration/utils/semver.ts
@@ -5,9 +5,28 @@ interface Versions {
 }
 type VersionType = 'patch' | 'minor' | 'major'
 
-const nextTypes: { [type: string]: VersionType } = {
-  patch: 'minor',
-  minor: 'major'
+export const increment = (version: string, type: VersionType = 'patch'): string => {
+  const versions = deconstruct(version)
+
+  up(versions, type)
+
+  return construct(versions)
+}
+
+const up = (v: Versions, type: VersionType): void => {
+  v[type] = String(Number(v[type]) + 1)
+
+  switch (type) {
+    case 'minor':
+      v.patch = '0'
+      break
+    case 'major':
+      v.patch = '0'
+      v.minor = '0'
+      break
+    default:
+      break
+  }
 }
 
 export const decrement = (version: string, type: VersionType = 'patch'): string => {
@@ -19,6 +38,11 @@ export const decrement = (version: string, type: VersionType = 'patch'): string 
 }
 
 const down = (v: Versions, type: VersionType): void => {
+  const nextTypes: { [type: string]: VersionType } = {
+    patch: 'minor',
+    minor: 'major'
+  }
+
   if (v[type] === '0') {
     v[type] = '99'
 

--- a/packages/server/test/migration/utils/server.ts
+++ b/packages/server/test/migration/utils/server.ts
@@ -61,10 +61,10 @@ export const startMessagingServer = async (options: JestDevServerOptions, prefix
       server.on('close', (code) => {
         process.env = defaultEnv
 
-        if (code === 0) {
+        if (code === 0 && errors.length === 0) {
           resolve(undefined)
         } else {
-          reject(errors.join('\n'))
+          reject(new Error(errors.join('\n')))
         }
       })
     })

--- a/packages/server/test/migration/utils/server.ts
+++ b/packages/server/test/migration/utils/server.ts
@@ -12,8 +12,6 @@ const extractError = (str: string) => {
 }
 
 export const startMessagingServer = async (options: JestDevServerOptions, prefix: string) => {
-  const defaultEnv = { ...process.env }
-
   process.env.SKIP_LOAD_ENV = 'true'
   process.env.DATABASE_URL =
     process.env.DATABASE_URL || path.join(__dirname, './../../../../../test/.test-data', `${prefix}.sqlite`)
@@ -26,8 +24,6 @@ export const startMessagingServer = async (options: JestDevServerOptions, prefix
 
   if (options.path) {
     await setup(options)
-
-    process.env = defaultEnv
 
     return teardown()
   } else {
@@ -59,8 +55,6 @@ export const startMessagingServer = async (options: JestDevServerOptions, prefix
       })
 
       server.on('close', (code) => {
-        process.env = defaultEnv
-
         if (code === 0 && errors.length === 0) {
           resolve(undefined)
         } else {


### PR DESCRIPTION
Self-explanatory. We cover all the unhappy and happy paths that a user can take when interfacing with the migration CLI.

Here are the options: 

- `--auto-migrate`
- `migrate <up|down> [--target <target>] [--dry]`