### PR TITLE
feat(channels): custom channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Botpress messaging repo",
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-base",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/packages/base/src/endpoint.ts
+++ b/packages/base/src/endpoint.ts
@@ -1,5 +1,5 @@
 export interface Endpoint {
-  channel: { name: string; version: string }
+  channel: string | { name: string; version: string }
   identity: string
   sender: string
   thread: string

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-client",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-client",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
@@ -41,7 +41,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@botpress/messaging-base": "1.1.0",
+    "@botpress/messaging-base": "1.1.1",
     "axios": "^0.21.4",
     "cookie": "^0.4.2",
     "joi": "^17.6.0"

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -33,7 +33,7 @@ export const Schemas = {
         .object({
           id: joi.string().uuid().required(),
           conversationId: joi.string().uuid().required(),
-          authorId: joi.string().uuid().required(),
+          authorId: joi.string().uuid().optional(),
           sentOn: joi.date().required(),
           payload: joi.object().required()
         })

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/webchat-inject",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "AGPL-3.0",
   "scripts": {
     "build": "yarn && yarn run -T parcel build src/index.html src/inject.js --public-url ./",
@@ -21,7 +21,7 @@
     "@types/react-dom": "^17.0.11"
   },
   "dependencies": {
-    "@botpress/webchat": "0.3.0",
+    "@botpress/webchat": "0.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-server",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/server/src/base/source.ts
+++ b/packages/server/src/base/source.ts
@@ -1,10 +1,8 @@
-import { uuid } from '@botpress/messaging-base'
 import { Endpoint } from '@botpress/messaging-channels'
 
 /**
  * Indicates whether an action is performed due to a request made by
  * - a conduit (we receive a request from an external service such as Telegram)
- * - a client (using the http api with a clientId and clientToken)
  * - a socket (using a websocket connection)
  *
  * Knowing this allows messaging to avoid redundantly
@@ -12,6 +10,5 @@ import { Endpoint } from '@botpress/messaging-channels'
  */
 export interface ActionSource {
   endpoint?: Endpoint
-  client?: { id: uuid }
   socket?: { id: string }
 }

--- a/packages/server/src/base/streamer.ts
+++ b/packages/server/src/base/streamer.ts
@@ -67,15 +67,14 @@ export class Streamer {
       await this.dispatcher.publish(StreamerDispatches.Message, userId, { source: source?.socket?.id, payload })
     }
 
-    if (source?.client?.id !== clientId) {
-      const webhooks = await this.webhooks.list(clientId)
+    // TODO: this might break stuff on botpress's side
+    const webhooks = await this.webhooks.list(clientId)
 
-      for (const webhook of webhooks) {
-        void this.send(process.env.SPINNED_URL || webhook.url, payload, {
-          'x-bp-messaging-client-id': clientId,
-          'x-bp-messaging-webhook-token': webhook.token
-        })
-      }
+    for (const webhook of webhooks) {
+      void this.send(process.env.SPINNED_URL || webhook.url, payload, {
+        'x-bp-messaging-client-id': clientId,
+        'x-bp-messaging-webhook-token': webhook.token
+      })
     }
   }
 

--- a/packages/server/src/base/streamer.ts
+++ b/packages/server/src/base/streamer.ts
@@ -67,7 +67,6 @@ export class Streamer {
       await this.dispatcher.publish(StreamerDispatches.Message, userId, { source: source?.socket?.id, payload })
     }
 
-    // TODO: this might break stuff on botpress's side
     const webhooks = await this.webhooks.list(clientId)
 
     for (const webhook of webhooks) {

--- a/packages/server/src/conversations/stream.ts
+++ b/packages/server/src/conversations/stream.ts
@@ -40,7 +40,7 @@ export class ConversationStream {
     const convmaps = await this.mapping.convmap.listByConversationId(conversationId)
     if (convmaps.length === 1) {
       const tunnel = await this.mapping.tunnels.get(convmaps[0].tunnelId)
-      return this.channels.getById(tunnel!.channelId).meta.name
+      return tunnel!.customChannelName ? tunnel!.customChannelName : this.channels.getById(tunnel!.channelId!).meta.name
     } else {
       return 'messaging'
     }

--- a/packages/server/src/instances/messaging/service.ts
+++ b/packages/server/src/instances/messaging/service.ts
@@ -59,9 +59,12 @@ export class InstanceMessagingService extends Service {
     for (const { threadId, tunnelId } of convmaps) {
       const endpoint = await this.mapping.getEndpoint(threadId)
       const tunnel = await this.mapping.tunnels.get(tunnelId)
+      if (!tunnel?.channelId) {
+        continue
+      }
 
       if (!source?.endpoint || !this.endpointEqual(source.endpoint, endpoint)) {
-        const conduit = await this.conduits.fetchByProviderAndChannel(provision.providerId, tunnel!.channelId)
+        const conduit = await this.conduits.fetchByProviderAndChannel(provision.providerId, tunnel.channelId)
         if (!conduit) {
           return
         }

--- a/packages/server/src/mapping/schema.ts
+++ b/packages/server/src/mapping/schema.ts
@@ -5,14 +5,15 @@ import { ReqSchema } from '../base/schema'
 export const makeMapRequestSchema = (channels: Channel[]) => {
   return ReqSchema({
     body: {
-      channel: Joi.alternatives(
-        channels.map((x) =>
+      channel: Joi.alternatives([
+        Joi.string(),
+        ...channels.map((x) =>
           Joi.object({
             name: Joi.string().valid(x.meta.name).required(),
             version: Joi.string().valid(x.meta.version).required()
           })
         )
-      ).required(),
+      ]).required(),
       identity: Joi.string().required(),
       sender: Joi.string().required(),
       thread: Joi.string().required()

--- a/packages/server/src/mapping/service.ts
+++ b/packages/server/src/mapping/service.ts
@@ -68,14 +68,23 @@ export class MappingService extends Service {
 
   async getMapping(clientId: uuid, channelId: uuid, endpoint: Endpoint): Promise<Mapping> {
     const tunnel = await this.tunnels.map(clientId, channelId)
-    const identity = await this.identities.map(tunnel.id, endpoint.identity)
+    return this.getMappingFromTunnel(tunnel.id, endpoint)
+  }
+
+  async getCustomMapping(clientId: uuid, customChannelName: string, endpoint: Endpoint): Promise<Mapping> {
+    const tunnel = await this.tunnels.mapCustom(clientId, customChannelName)
+    return this.getMappingFromTunnel(tunnel.id, endpoint)
+  }
+
+  private async getMappingFromTunnel(tunnelId: uuid, endpoint: Endpoint) {
+    const identity = await this.identities.map(tunnelId, endpoint.identity)
     const sender = await this.senders.map(identity.id, endpoint.sender)
     const thread = await this.threads.map(sender.id, endpoint.thread)
-    const usermap = await this.usermap.map(tunnel.id, sender.id)
-    const convmap = await this.convmap.map(tunnel.id, thread.id, usermap.userId)
+    const usermap = await this.usermap.map(tunnelId, sender.id)
+    const convmap = await this.convmap.map(tunnelId, thread.id, usermap.userId)
 
     return {
-      tunnelId: tunnel.id,
+      tunnelId,
       identityId: identity.id,
       senderId: sender.id,
       threadId: thread.id,

--- a/packages/server/src/mapping/tunnels/table.ts
+++ b/packages/server/src/mapping/tunnels/table.ts
@@ -10,7 +10,7 @@ export class TunnelTable extends Table {
     table.uuid('id').primary()
     table.uuid('clientId').references('id').inTable(getTableId('msg_clients')).notNullable()
     table.uuid('channelId').references('id').inTable(getTableId('msg_channels')).nullable()
-    table.uuid('customChannelName').nullable()
+    table.string('customChannelName').nullable()
     table.unique(['clientId', 'channelId'])
     table.unique(['clientId', 'customChannelName'])
   }

--- a/packages/server/src/mapping/tunnels/table.ts
+++ b/packages/server/src/mapping/tunnels/table.ts
@@ -9,7 +9,9 @@ export class TunnelTable extends Table {
   create(table: Knex.CreateTableBuilder) {
     table.uuid('id').primary()
     table.uuid('clientId').references('id').inTable(getTableId('msg_clients')).notNullable()
-    table.uuid('channelId').references('id').inTable(getTableId('msg_channels')).notNullable()
+    table.uuid('channelId').references('id').inTable(getTableId('msg_channels')).nullable()
+    table.uuid('customChannelName').nullable()
     table.unique(['clientId', 'channelId'])
+    table.unique(['clientId', 'customChannelName'])
   }
 }

--- a/packages/server/src/mapping/tunnels/types.ts
+++ b/packages/server/src/mapping/tunnels/types.ts
@@ -3,5 +3,6 @@ import { uuid } from '@botpress/messaging-base'
 export interface Tunnel {
   id: uuid
   clientId: uuid
-  channelId: uuid
+  channelId?: uuid
+  customChannelName?: string
 }

--- a/packages/server/src/messages/api.ts
+++ b/packages/server/src/messages/api.ts
@@ -56,13 +56,7 @@ export class MessageApi {
       this.converse.setIncomingId(messageId, incomingId)
     }
 
-    const source = authorId
-      ? undefined
-      : {
-          client: { id: req.clientId }
-        }
-    const message = await this.messages.create(conversationId, authorId, payload, source, messageId)
-
+    const message = await this.messages.create(conversationId, authorId, payload, undefined, messageId)
     res.status(201).send(message)
   }
 

--- a/packages/server/src/messages/stream.ts
+++ b/packages/server/src/messages/stream.ts
@@ -61,7 +61,7 @@ export class MessageStream {
     const convmaps = await this.mapping.convmap.listByConversationId(conversationId)
     if (convmaps.length === 1) {
       const tunnel = await this.mapping.tunnels.get(convmaps[0].tunnelId)
-      return this.channels.getById(tunnel!.channelId).meta.name
+      return tunnel!.customChannelName ? tunnel!.customChannelName : this.channels.getById(tunnel!.channelId!).meta.name
     } else {
       return 'messaging'
     }

--- a/packages/server/src/migrations/1.1.7-custom-channels.ts
+++ b/packages/server/src/migrations/1.1.7-custom-channels.ts
@@ -4,7 +4,7 @@ export class CustomChannelsMigration extends Migration {
   meta = {
     name: CustomChannelsMigration.name,
     description: 'Modifies the msg_tunnels table to support custom channels',
-    version: '1.1.5'
+    version: '1.1.7'
   }
 
   async valid() {

--- a/packages/server/src/migrations/1.1.7-custom-channels.ts
+++ b/packages/server/src/migrations/1.1.7-custom-channels.ts
@@ -22,5 +22,12 @@ export class CustomChannelsMigration extends Migration {
     })
   }
 
-  async down() {}
+  async down() {
+    await this.trx(getTableId('msg_tunnels')).whereNull('channelId').del()
+
+    await this.trx.schema.alterTable(getTableId('msg_tunnels'), (table) => {
+      table.uuid('channelId').notNullable().alter()
+      table.dropColumn('customChannelName')
+    })
+  }
 }

--- a/packages/server/src/migrations/1.1.7-custom-channels.ts
+++ b/packages/server/src/migrations/1.1.7-custom-channels.ts
@@ -19,6 +19,7 @@ export class CustomChannelsMigration extends Migration {
     await this.trx.schema.alterTable(getTableId('msg_tunnels'), (table) => {
       table.uuid('channelId').nullable().alter()
       table.string('customChannelName').nullable()
+      table.unique(['clientId', 'customChannelName'])
     })
   }
 
@@ -27,6 +28,7 @@ export class CustomChannelsMigration extends Migration {
 
     await this.trx.schema.alterTable(getTableId('msg_tunnels'), (table) => {
       table.uuid('channelId').notNullable().alter()
+      table.dropUnique(['clientId', 'customChannelName'])
       table.dropColumn('customChannelName')
     })
   }

--- a/packages/server/src/migrations/1.1.7-custom-channels.ts
+++ b/packages/server/src/migrations/1.1.7-custom-channels.ts
@@ -1,0 +1,26 @@
+import { getTableId, Migration } from '@botpress/messaging-engine'
+
+export class CustomChannelsMigration extends Migration {
+  meta = {
+    name: CustomChannelsMigration.name,
+    description: 'Modifies the msg_tunnels table to support custom channels',
+    version: '1.1.5'
+  }
+
+  async valid() {
+    return true
+  }
+
+  async applied() {
+    return this.trx.schema.hasColumn(getTableId('msg_tunnels'), 'customChannelName')
+  }
+
+  async up() {
+    await this.trx.schema.alterTable(getTableId('msg_tunnels'), (table) => {
+      table.uuid('channelId').nullable().alter()
+      table.string('customChannelName').nullable()
+    })
+  }
+
+  async down() {}
+}

--- a/packages/server/src/migrations/index.ts
+++ b/packages/server/src/migrations/index.ts
@@ -7,6 +7,7 @@ import { ChannelVersionsMigration } from './1.0.2-channel-versions'
 import { UserTokensMigration } from './1.1.0-user-tokens'
 import { ProvisionsMigration } from './1.1.5-a-provisions'
 import { MoveProviderIdMigration } from './1.1.5-b-move-provider-id'
+import { CustomChannelsMigration } from './1.1.7-custom-channels'
 
 export const Migrations: { new (): Migration }[] = [
   InitMigration,
@@ -16,5 +17,6 @@ export const Migrations: { new (): Migration }[] = [
   ChannelVersionsMigration,
   UserTokensMigration,
   ProvisionsMigration,
-  MoveProviderIdMigration
+  MoveProviderIdMigration,
+  CustomChannelsMigration
 ]

--- a/packages/server/test/integration/mapping.test.ts
+++ b/packages/server/test/integration/mapping.test.ts
@@ -27,6 +27,8 @@ describe('Mapping', () => {
   let clientId: uuid
   let channelId: uuid
   let channelId2: uuid
+  let customChannelName: string
+  let customChannelName2: string
   const state: { provider?: Provider; endpoint?: Endpoint; mapping?: Mapping } = {}
 
   beforeAll(async () => {
@@ -35,6 +37,8 @@ describe('Mapping', () => {
     clientId = (await app.clients.create()).id
     channelId = app.channels.getByNameAndVersion('telegram', '1.0.0').meta.id
     channelId2 = app.channels.getByNameAndVersion('twilio', '1.0.0').meta.id
+    customChannelName = randStr()
+    customChannelName2 = randStr()
   })
 
   afterAll(async () => {
@@ -187,5 +191,151 @@ describe('Mapping', () => {
     for (const mapping of mappings) {
       expect(mapping).toEqual(mappings[0])
     }
+  })
+
+  describe('Custom', () => {
+    test('Mapping an endpoint', async () => {
+      state.endpoint = generateEndpoint()
+      const map = await mapping.getCustomMapping(clientId, customChannelName, state.endpoint)
+
+      expect(map).toBeDefined()
+      expect(validateUuid(map.tunnelId)).toBeTruthy()
+      expect(validateUuid(map.identityId)).toBeTruthy()
+      expect(validateUuid(map.senderId)).toBeTruthy()
+      expect(validateUuid(map.threadId)).toBeTruthy()
+      expect(validateUuid(map.userId)).toBeTruthy()
+      expect(validateUuid(map.conversationId)).toBeTruthy()
+
+      state.mapping = map
+    })
+
+    test('Mapping the same endpoint again returns the same mapping', async () => {
+      const map = await mapping.getCustomMapping(clientId, customChannelName, state.endpoint!)
+
+      expect(map).toEqual(state.mapping)
+    })
+
+    test('Mapping a completely different endpoint returns a completely different mapping', async () => {
+      const endpoint = generateEndpoint()
+      const map = await mapping.getCustomMapping(clientId, customChannelName2, endpoint)
+
+      expect(map.tunnelId).not.toBe(state.mapping!.tunnelId)
+      expect(map.identityId).not.toBe(state.mapping!.identityId)
+      expect(map.senderId).not.toBe(state.mapping!.senderId)
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.userId).not.toBe(state.mapping!.userId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Mapping an endpoint with the same channel returns only the same tunnel', async () => {
+      const endpoint = generateEndpoint()
+      const map = await mapping.getCustomMapping(clientId, customChannelName, endpoint)
+
+      expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+
+      expect(map.identityId).not.toBe(state.mapping!.identityId)
+      expect(map.senderId).not.toBe(state.mapping!.senderId)
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.userId).not.toBe(state.mapping!.userId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Mapping an endpoint with the same channel and identity returns only the same tunnel and identity', async () => {
+      const endpoint = generateEndpoint({ identity: state.endpoint!.identity })
+      const map = await mapping.getCustomMapping(clientId, customChannelName, endpoint)
+
+      expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+      expect(map.identityId).toBe(state.mapping!.identityId)
+
+      expect(map.senderId).not.toBe(state.mapping!.senderId)
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.userId).not.toBe(state.mapping!.userId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Mapping an endpoint with the same channel, identity and sender returns only the same tunnel, identity, senderId and userId', async () => {
+      const endpoint = generateEndpoint({ identity: state.endpoint!.identity, sender: state.endpoint!.sender })
+      const map = await mapping.getCustomMapping(clientId, customChannelName, endpoint)
+
+      expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+      expect(map.identityId).toBe(state.mapping!.identityId)
+      expect(map.senderId).toBe(state.mapping!.senderId)
+      expect(map.userId).toBe(state.mapping!.userId)
+
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Mapping an endpoint with only the same identity returns a completely different mapping', async () => {
+      const endpoint = generateEndpoint({ identity: state.endpoint!.identity })
+      const map = await mapping.getCustomMapping(clientId, customChannelName2, endpoint)
+
+      expect(map.tunnelId).not.toBe(state.mapping!.tunnelId)
+      expect(map.identityId).not.toBe(state.mapping!.identityId)
+      expect(map.senderId).not.toBe(state.mapping!.senderId)
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.userId).not.toBe(state.mapping!.userId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Mapping an endpoint with only the same channel and sender returns a completely different mapping', async () => {
+      const endpoint = generateEndpoint({ sender: state.endpoint!.sender })
+      const map = await mapping.getCustomMapping(clientId, customChannelName, endpoint)
+
+      expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+
+      expect(map.identityId).not.toBe(state.mapping!.identityId)
+      expect(map.senderId).not.toBe(state.mapping!.senderId)
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.userId).not.toBe(state.mapping!.userId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Mapping an endpoint with only the same channel and thread returns a completely different mapping', async () => {
+      const endpoint = generateEndpoint({ thread: state.endpoint!.thread })
+      const map = await mapping.getCustomMapping(clientId, customChannelName, endpoint)
+
+      expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+
+      expect(map.identityId).not.toBe(state.mapping!.identityId)
+      expect(map.senderId).not.toBe(state.mapping!.senderId)
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.userId).not.toBe(state.mapping!.userId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Mapping an endpoint with the same channel, identity and thread does not return the same senderId and threadId', async () => {
+      const endpoint = generateEndpoint({ identity: state.endpoint!.identity, thread: state.endpoint!.thread })
+      const map = await mapping.getCustomMapping(clientId, customChannelName, endpoint)
+
+      expect(map.tunnelId).toBe(state.mapping!.tunnelId)
+      expect(map.identityId).toBe(state.mapping!.identityId)
+
+      expect(map.senderId).not.toBe(state.mapping!.senderId)
+      expect(map.threadId).not.toBe(state.mapping!.threadId)
+      expect(map.userId).not.toBe(state.mapping!.userId)
+      expect(map.conversationId).not.toBe(state.mapping!.conversationId)
+    })
+
+    test('Get endpoint from threadId', async () => {
+      const endpoint = await mapping.getEndpoint(state.mapping!.threadId!)
+      expect(endpoint).toEqual(state.endpoint)
+    })
+
+    test('Mapping repeatedly does not produce race conditions', async () => {
+      const endpoint = generateEndpoint()
+      const promises: Promise<Mapping>[] = []
+
+      for (let i = 0; i < 100; i++) {
+        promises.push(mapping.getCustomMapping(clientId, customChannelName, endpoint))
+      }
+
+      const mappings = await Promise.all(promises)
+
+      // they should have all mapped to the same thing
+      for (const mapping of mappings) {
+        expect(mapping).toEqual(mappings[0])
+      }
+    })
   })
 })

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-socket",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
@@ -22,7 +22,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@botpress/messaging-base": "1.1.0",
+    "@botpress/messaging-base": "1.1.1",
     "socket.io-client": "^4.4.1"
   }
 }

--- a/packages/webchat/package.json
+++ b/packages/webchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/webchat",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.tsx",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@blueprintjs/core": "^3.23.1",
     "@botpress/messaging-components": "0.3.0",
-    "@botpress/messaging-socket": "1.1.0",
+    "@botpress/messaging-socket": "1.1.1",
     "@formatjs/intl-pluralrules": "^4.1.6",
     "@formatjs/intl-utils": "^3.8.4",
     "@juggle/resize-observer": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,7 +2176,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/messaging-base@*, @botpress/messaging-base@1.1.0, @botpress/messaging-base@workspace:packages/base":
+"@botpress/messaging-base@*, @botpress/messaging-base@1.1.1, @botpress/messaging-base@workspace:packages/base":
   version: 0.0.0-use.local
   resolution: "@botpress/messaging-base@workspace:packages/base"
   languageName: unknown
@@ -2262,7 +2262,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@botpress/messaging-client@workspace:packages/client"
   dependencies:
-    "@botpress/messaging-base": 1.1.0
+    "@botpress/messaging-base": 1.1.1
     "@types/cookie": ^0.4.1
     "@types/express": ^4.17.13
     "@types/jest": ^27.4.0
@@ -2407,11 +2407,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/messaging-socket@*, @botpress/messaging-socket@1.1.0, @botpress/messaging-socket@workspace:packages/socket":
+"@botpress/messaging-socket@*, @botpress/messaging-socket@1.1.1, @botpress/messaging-socket@workspace:packages/socket":
   version: 0.0.0-use.local
   resolution: "@botpress/messaging-socket@workspace:packages/socket"
   dependencies:
-    "@botpress/messaging-base": 1.1.0
+    "@botpress/messaging-base": 1.1.1
     "@types/jest": ^27.4.0
     "@types/lodash": ^4.14.178
     "@types/node": ^16.11.13
@@ -2486,7 +2486,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@botpress/webchat-inject@workspace:packages/inject"
   dependencies:
-    "@botpress/webchat": 0.3.0
+    "@botpress/webchat": 0.3.1
     "@parcel/config-default": ^2.2.1
     "@parcel/reporter-bundle-analyzer": 2.2.1
     "@parcel/transformer-typescript-tsc": ^2.2.1
@@ -2497,13 +2497,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/webchat@*, @botpress/webchat@0.3.0, @botpress/webchat@workspace:packages/webchat":
+"@botpress/webchat@*, @botpress/webchat@0.3.1, @botpress/webchat@workspace:packages/webchat":
   version: 0.0.0-use.local
   resolution: "@botpress/webchat@workspace:packages/webchat"
   dependencies:
     "@blueprintjs/core": ^3.23.1
     "@botpress/messaging-components": 0.3.0
-    "@botpress/messaging-socket": 1.1.0
+    "@botpress/messaging-socket": 1.1.1
     "@formatjs/intl-pluralrules": ^4.1.6
     "@formatjs/intl-utils": ^3.8.4
     "@juggle/resize-observer": ^3.0.2


### PR DESCRIPTION
Adds a way to create mappings for any arbitrary string. The channel part of the endpoint doesn't have to be a predefined channel anymore

For a full demo of how to use this feature see : https://github.com/botpress/custom-channel

Closes DEV-2397