### PR TITLE
chore(ci_cd): allow pushing docker image when release is published

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,8 @@ on:
       - master
     tags:
       - v*
+  release:
+    types: [published]
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Self-explanatory. This fixes a problem where we had to manually run the action when a new release was published to have an image deployed with the new tag.