### PR TITLE
chore(tests): use services instead of cli

### DIFF
--- a/packages/server/test/migration/global-diff.test.ts
+++ b/packages/server/test/migration/global-diff.test.ts
@@ -22,7 +22,7 @@ describe('Global Diff', () => {
   test(
     'Starts Messaging with the latest database schema',
     async () => {
-      await setupApp({ prefix: NO_MIGRATION, seed: false })
+      await setupApp({ prefix: NO_MIGRATION, seed: false, transient: false })
     },
     TIMEOUT
   )
@@ -33,7 +33,7 @@ describe('Global Diff', () => {
       process.env.MIGRATE_CMD = 'up'
       process.env.TESTMIG_DB_VERSION = '0.0.0'
 
-      await handleShutDownSignal(() => setupApp({ prefix: ALL_MIGRATIONS, seed: false }))
+      await handleShutDownSignal(() => setupApp({ prefix: ALL_MIGRATIONS, seed: false, transient: false }))
     },
     TIMEOUT
   )

--- a/packages/server/test/migration/global-diff.test.ts
+++ b/packages/server/test/migration/global-diff.test.ts
@@ -1,29 +1,28 @@
-import portfinder from 'portfinder'
-
+import { destroyApp, setupApp } from '../utils'
 import { compareDatabases } from './utils/diff'
-import { startMessagingServer } from './utils/server'
+import { handleShutDownSignal } from './utils/error'
 
 const NO_MIGRATION = 'no_mig'
 const ALL_MIGRATIONS = 'all_migs'
 const TIMEOUT = 30000
 
 describe('Global Diff', () => {
+  let envCopy: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    envCopy = { ...process.env }
+  })
+
+  afterEach(async () => {
+    await destroyApp()
+
+    process.env = envCopy
+  })
+
   test(
     'Starts Messaging with the latest database schema',
     async () => {
-      const port = await portfinder.getPortPromise()
-      await startMessagingServer(
-        {
-          command: 'yarn dev',
-          launchTimeout: TIMEOUT,
-          protocol: 'http',
-          host: '127.0.0.1',
-          port,
-          path: 'status',
-          usedPortAction: 'error'
-        },
-        NO_MIGRATION
-      )
+      await setupApp({ prefix: NO_MIGRATION, seed: false })
     },
     TIMEOUT
   )
@@ -31,13 +30,10 @@ describe('Global Diff', () => {
   test(
     'Starts Messaging and runs all migrations',
     async () => {
-      await startMessagingServer(
-        {
-          command: 'yarn dev migrate up',
-          launchTimeout: TIMEOUT
-        },
-        ALL_MIGRATIONS
-      )
+      process.env.MIGRATE_CMD = 'up'
+      process.env.TESTMIG_DB_VERSION = '0.0.0'
+
+      await handleShutDownSignal(() => setupApp({ prefix: ALL_MIGRATIONS, seed: false }))
     },
     TIMEOUT
   )

--- a/packages/server/test/migration/migration-cli.test.ts
+++ b/packages/server/test/migration/migration-cli.test.ts
@@ -19,14 +19,14 @@ describe('Migration CLI', () => {
     // Speeds up tests
     await buildMessagingServer({
       command: 'yarn build',
-      launchTimeout: TIMEOUT
+      launchTimeout: TIMEOUT * 2
     })
 
     const connectionInfo = setupConnection(CLI_MIGRATIONS)
 
     conn = connectionInfo.conn
     isLite = connectionInfo.isLite
-  }, TIMEOUT)
+  }, TIMEOUT * 2)
 
   afterAll(async () => {
     await conn.destroy()

--- a/packages/server/test/migration/migration-cli.test.ts
+++ b/packages/server/test/migration/migration-cli.test.ts
@@ -19,14 +19,14 @@ describe('Migration CLI', () => {
     // Speeds up tests
     await buildMessagingServer({
       command: 'yarn build',
-      launchTimeout: TIMEOUT * 2
+      launchTimeout: TIMEOUT * 4
     })
 
     const connectionInfo = setupConnection(CLI_MIGRATIONS)
 
     conn = connectionInfo.conn
     isLite = connectionInfo.isLite
-  }, TIMEOUT * 2)
+  }, TIMEOUT * 4)
 
   afterAll(async () => {
     await conn.destroy()

--- a/packages/server/test/migration/migration-cli.test.ts
+++ b/packages/server/test/migration/migration-cli.test.ts
@@ -4,7 +4,7 @@ import portfinder from 'portfinder'
 
 import { setupConnection } from './utils/database'
 import { decrement, increment } from './utils/semver'
-import { startMessagingServer } from './utils/server'
+import { buildMessagingServer, startMessagingServer } from './utils/server'
 
 const pkg = require('../../package.json')
 
@@ -15,12 +15,18 @@ describe('Migration CLI', () => {
   let conn: Knex
   let isLite: boolean
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    // Speeds up tests
+    await buildMessagingServer({
+      command: 'yarn build',
+      launchTimeout: TIMEOUT
+    })
+
     const connectionInfo = setupConnection(CLI_MIGRATIONS)
 
     conn = connectionInfo.conn
     isLite = connectionInfo.isLite
-  })
+  }, TIMEOUT)
 
   afterAll(async () => {
     await conn.destroy()
@@ -47,7 +53,7 @@ describe('Migration CLI', () => {
     async () => {
       await startMessagingServer(
         {
-          command: 'yarn dev migrate up --dry',
+          command: 'yarn start migrate up --dry',
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -66,7 +72,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: 'yarn dev --auto-migrate',
+          command: 'yarn start --auto-migrate',
           launchTimeout: TIMEOUT,
           protocol: 'http',
           host: '127.0.0.1',
@@ -89,7 +95,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: `yarn dev migrate down --target ${target}`,
+          command: `yarn start migrate down --target ${target}`,
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -99,7 +105,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: 'yarn dev migrate up',
+          command: 'yarn start migrate up',
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -117,7 +123,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: `yarn dev migrate down --target ${target}`,
+          command: `yarn start migrate down --target ${target}`,
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -135,7 +141,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: `yarn dev migrate up --target ${target}`,
+          command: `yarn start migrate up --target ${target}`,
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -151,7 +157,7 @@ describe('Migration CLI', () => {
     async () => {
       await startMessagingServer(
         {
-          command: 'yarn dev migrate down',
+          command: 'yarn start migrate down',
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -171,7 +177,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn dev migrate down --target ${target}`,
+            command: `yarn start migrate down --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS
@@ -192,7 +198,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn dev migrate up --target ${target}`,
+            command: `yarn start migrate up --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS
@@ -213,7 +219,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn dev migrate up --target ${target}`,
+            command: `yarn start migrate up --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS
@@ -233,7 +239,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn dev migrate up --target ${target}`,
+            command: `yarn start migrate up --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS

--- a/packages/server/test/migration/migrations-diff.test.ts
+++ b/packages/server/test/migration/migrations-diff.test.ts
@@ -42,7 +42,7 @@ describe('Migrations diff tests', () => {
         process.env.TESTMIG_DB_VERSION = '0.0.0'
         process.env.MIGRATE_TARGET = previousVersion
 
-        await handleShutDownSignal(() => setupApp({ prefix: beforeMigrationDatabase, seed: false }))
+        await handleShutDownSignal(() => setupApp({ prefix: beforeMigrationDatabase, seed: false, transient: false }))
       },
       TIMEOUT
     )
@@ -53,7 +53,7 @@ describe('Migrations diff tests', () => {
         process.env.MIGRATE_CMD = 'up'
         process.env.MIGRATE_TARGET = migrationVersion
 
-        await handleShutDownSignal(() => setupApp({ prefix: afterMigrationDatabase, seed: false }))
+        await handleShutDownSignal(() => setupApp({ prefix: afterMigrationDatabase, seed: false, transient: false }))
       },
       TIMEOUT
     )
@@ -64,7 +64,7 @@ describe('Migrations diff tests', () => {
         process.env.MIGRATE_CMD = 'down'
         process.env.MIGRATE_TARGET = previousVersion
 
-        await handleShutDownSignal(() => setupApp({ prefix: afterMigrationDatabase, seed: false }))
+        await handleShutDownSignal(() => setupApp({ prefix: afterMigrationDatabase, seed: false, transient: false }))
       },
       TIMEOUT
     )

--- a/packages/server/test/migration/utils/error.ts
+++ b/packages/server/test/migration/utils/error.ts
@@ -1,0 +1,13 @@
+import { ShutDownSignal } from '@botpress/messaging-engine'
+
+export const handleShutDownSignal = async <T>(fn: () => PromiseLike<T>) => {
+  try {
+    await fn()
+  } catch (e) {
+    if (!(e instanceof ShutDownSignal)) {
+      throw e
+    } else if (e.code && e.code > 0) {
+      throw new Error(`Process exited with a non zero error code: ${e.code}`)
+    }
+  }
+}

--- a/packages/server/test/migration/utils/server.ts
+++ b/packages/server/test/migration/utils/server.ts
@@ -64,3 +64,7 @@ export const startMessagingServer = async (options: JestDevServerOptions, prefix
     })
   }
 }
+
+export const buildMessagingServer = async (options: Pick<JestDevServerOptions, 'command' | 'launchTimeout'>) => {
+  await startMessagingServer(options, '')
+}

--- a/packages/server/test/utils/index.ts
+++ b/packages/server/test/utils/index.ts
@@ -7,7 +7,9 @@ import { Seed } from './seed'
 
 export let app: App
 
-export const setupApp = async ({ seed, prefix }: { seed: boolean; prefix?: string } = { seed: false }) => {
+export const setupApp = async (
+  { seed, prefix, transient }: { seed: boolean; transient: boolean; prefix?: string } = { seed: false, transient: true }
+) => {
   process.env.SKIP_LOAD_ENV = 'true'
   process.env.SUPPRESS_LOGGING = 'true'
   process.env.DATABASE_URL =
@@ -15,7 +17,7 @@ export const setupApp = async ({ seed, prefix }: { seed: boolean; prefix?: strin
 
   if (process.env.DATABASE_URL.startsWith('postgres')) {
     process.env.DATABASE_SUFFIX = `__${prefix || randomLetters(8)}`
-    process.env.DATABASE_TRANSIENT = 'true'
+    transient && (process.env.DATABASE_TRANSIENT = 'true')
   }
 
   app = new App()

--- a/packages/server/test/utils/index.ts
+++ b/packages/server/test/utils/index.ts
@@ -7,14 +7,14 @@ import { Seed } from './seed'
 
 export let app: App
 
-export const setupApp = async ({ seed }: { seed: boolean } = { seed: false }) => {
+export const setupApp = async ({ seed, prefix }: { seed: boolean; prefix?: string } = { seed: false }) => {
   process.env.SKIP_LOAD_ENV = 'true'
   process.env.SUPPRESS_LOGGING = 'true'
   process.env.DATABASE_URL =
-    process.env.DATABASE_URL || path.join(__dirname, '../../../../../test/.test-data', `${uuidv4()}.sqlite`)
+    process.env.DATABASE_URL || path.join(__dirname, '../../../../test/.test-data', `${prefix || uuidv4()}.sqlite`)
 
   if (process.env.DATABASE_URL.startsWith('postgres')) {
-    process.env.DATABASE_SUFFIX = `__${randomLetters(8)}`
+    process.env.DATABASE_SUFFIX = `__${prefix || randomLetters(8)}`
     process.env.DATABASE_TRANSIENT = 'true'
   }
 


### PR DESCRIPTION
This PR improves the migration tests by using services directly instead of using the CLI for each test. This improves the speed of global and migration diff tests by a factor of at least 15. 

I also improve the time it takes to run the CLI test by having a step that builds the server before running. This change removes the unnecessary call to `yarn start` each time we interact with the CLI.