### PR TITLE
chore(tests): use random unused port for e2e tests

### DIFF
--- a/packages/client/test/e2e/client.test.ts
+++ b/packages/client/test/e2e/client.test.ts
@@ -19,7 +19,7 @@ describe('Http Client', () => {
     expect((client as any).channel.http.defaults.baseURL).toContain(url)
   })
 
-  const url = 'http://localhost:3100'
+  const url = `http://localhost:${process.env.PORT}`
   const adminClient = new MessagingChannel({ url, adminKey: process.env.ADMIN_KEY })
 
   describe('Clients', () => {

--- a/packages/server/test/security/api.test.ts
+++ b/packages/server/test/security/api.test.ts
@@ -18,7 +18,7 @@ const FAKE_CLIENT_TOKEN = froth(TOKEN_LENGTH, TOKEN_LENGTH, {
 })
 
 const http = (clientId?: string, clientToken?: string) => {
-  const config: AxiosRequestConfig = { baseURL: 'http://localhost:3100' }
+  const config: AxiosRequestConfig = { baseURL: `http://localhost:${process.env.PORT}` }
 
   if (clientId && clientToken) {
     config.headers = {}

--- a/packages/socket/test/e2e/socket.test.ts
+++ b/packages/socket/test/e2e/socket.test.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import { v4 as uuid } from 'uuid'
 import { Conversation, Message, MessagingSocket } from '../../src'
 
-const MESSAGING_SERVER_URL = 'http://localhost:3100'
+const MESSAGING_SERVER_URL = `http://localhost:${process.env.PORT}`
 
 const createClient = async () => {
   const url = new URL(MESSAGING_SERVER_URL)

--- a/test/jest.e2e.setup.ts
+++ b/test/jest.e2e.setup.ts
@@ -3,6 +3,7 @@ require('ts-node/register')
 
 import { setup as setupDevServer } from 'jest-dev-server'
 import path from 'path'
+import portfinder from 'portfinder'
 import { v4 as uuidv4 } from 'uuid'
 
 const setup = async () => {
@@ -14,24 +15,18 @@ const setup = async () => {
     process.env.DATABASE_TRANSIENT = 'true'
   }
 
+  const port = await portfinder.getPortPromise()
+  process.env.PORT = port.toString()
+
   await setupDevServer({
     command: 'yarn dev',
     launchTimeout: 30000,
     protocol: 'http',
     host: '127.0.0.1',
-    port: 3100,
+    port,
     path: 'status',
     usedPortAction: 'error'
   })
-}
-
-const randomLetters = (length: number) => {
-  const chars = 'abcdefghijklmnopqrstuvwxyz'
-  let str = ''
-  for (let i = 0; i < length; i++) {
-    str += chars.charAt(Math.floor(Math.random() * chars.length))
-  }
-  return str
 }
 
 export default setup


### PR DESCRIPTION
This PR changes the E2E test setup so that we don't rely on a hard-coded port number but instead use a random unused port.

This allows us to have a running messaging server when running tests without having it conflict with them.