### PR TITLE
chore(ci_cd): adapt ci with changes make on yarn scripts and folder structure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           yarn --immutable
       - name: Build Messaging
         run: |
-          yarn build
+          yarn workspace @botpress/messaging-server build
 
   # Taken from: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache
   docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
 
   studio:
     name: Studio
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: files_changed
     if: needs.files_changed.outputs.studio == 'true'
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
 
   studio:
     name: Studio
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: files_changed
     if: needs.files_changed.outputs.studio == 'true'
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build and Package
         run: |
-          yarn build
+          yarn workspace @botpress/messaging-server build
           yarn package
 
       - name: Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,15 @@
 name: Tests
 on: [pull_request]
+
 jobs:
+  files_changed:
+    uses: 'botpress/messaging/.github/workflows/files-changed.yml@master'
+
   unit:
     name: Unit
     runs-on: ubuntu-latest
-
+    needs: files_changed
+    if: needs.files_changed.outputs.messaging == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -25,7 +30,8 @@ jobs:
     strategy:
       matrix:
         database: ['sqlite', 'postgres']
-
+    needs: files_changed
+    if: needs.files_changed.outputs.messaging == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -60,7 +66,8 @@ jobs:
     strategy:
       matrix:
         database: ['sqlite', 'postgres']
-
+    needs: files_changed
+    if: needs.files_changed.outputs.messaging == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -95,7 +102,8 @@ jobs:
     strategy:
       matrix:
         database: ['sqlite', 'postgres']
-
+    needs: files_changed
+    if: needs.files_changed.outputs.messaging == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -130,7 +138,8 @@ jobs:
     strategy:
       matrix:
         database: ['sqlite', 'postgres']
-
+    needs: files_changed
+    if: needs.files_changed.outputs.messaging == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -165,7 +174,8 @@ jobs:
     strategy:
       matrix:
         browser: ['chrome', 'firefox']
-
+    needs: files_changed
+    if: needs.files_changed.outputs.webchat == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@master

--- a/.github/workflows/upload-webchat-production.yml
+++ b/.github/workflows/upload-webchat-production.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./packages/inject
+        working-directory: ./packages/webchat/inject
     steps:
       - uses: actions/checkout@v2.1.0
       - uses: actions/setup-node@v2
@@ -29,7 +29,7 @@ jobs:
           yarn write:version
       - uses: botpress/gh-actions/deploy/s3@v2
         with:
-          source: ./packages/inject/dist
+          source: ./packages/webchat/inject/dist
           bucket: ${{ secrets.AWS_WEBCHAT_BUCKET_NAME }}
           aws-role: ${{ secrets.AWS_WEBCHAT_UPLOAD_ROLE }}
           prefix: webchat/v0 # TODO: Change the version (for test purpose)

--- a/.github/workflows/upload-webchat-staging.yml
+++ b/.github/workflows/upload-webchat-staging.yml
@@ -4,10 +4,10 @@ on:
     branches:
       - master
     paths:
-      - 'packages/inject/**'
-      - 'packages/components/**'
-      - 'packages/webchat/**'
-      - 'packages/socket/**'
+      - 'packages/webchat/inject/**'
+      - 'packages/webchat/components/**'
+      - 'packages/webchat/webchat/**'
+      - 'packages/messaging/socket/**'
 
 permissions:
   id-token: write
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./packages/inject
+        working-directory: ./packages/webchat/inject
     steps:
       - uses: actions/checkout@v2.1.0
       - uses: actions/setup-node@v2
@@ -36,7 +36,7 @@ jobs:
           yarn write:version
       - uses: botpress/gh-actions/deploy/s3@v2
         with:
-          source: ./packages/inject/dist
+          source: ./packages/webchat/inject/dist
           bucket: ${{ secrets.AWS_WEBCHAT_BUCKET_NAME }}
           aws-role: ${{ secrets.AWS_WEBCHAT_UPLOAD_ROLE }}
           cloudfront-distribution: ${{ secrets.AWS_WEBCHAT_CLOUDFRONT_DISTRIBUTION_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /messaging
 WORKDIR /messaging
 
 RUN yarn --immutable
-RUN yarn build
+RUN yarn workspace @botpress/messaging-server build
 
 FROM node:16.13.2-alpine
 

--- a/packages/messaging/server/test/migration/migration-cli.test.ts
+++ b/packages/messaging/server/test/migration/migration-cli.test.ts
@@ -17,7 +17,7 @@ describe('Migration CLI', () => {
   beforeAll(async () => {
     // Speeds up tests
     await buildMessagingServer({
-      command: 'yarn build',
+      command: 'yarn workspace @botpress/messaging-server build',
       launchTimeout: TIMEOUT * 4
     })
 

--- a/packages/messaging/server/test/migration/migration-cli.test.ts
+++ b/packages/messaging/server/test/migration/migration-cli.test.ts
@@ -52,7 +52,7 @@ describe('Migration CLI', () => {
     async () => {
       await startMessagingServer(
         {
-          command: 'yarn start migrate up --dry',
+          command: 'yarn workspace @botpress/messaging-server start migrate up --dry',
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -71,7 +71,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: 'yarn start --auto-migrate',
+          command: 'yarn workspace @botpress/messaging-server start --auto-migrate',
           launchTimeout: TIMEOUT,
           protocol: 'http',
           host: '127.0.0.1',
@@ -94,7 +94,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: `yarn start migrate down --target ${target}`,
+          command: `yarn workspace @botpress/messaging-server start migrate down --target ${target}`,
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -104,7 +104,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: 'yarn start migrate up',
+          command: 'yarn workspace @botpress/messaging-server start migrate up',
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -122,7 +122,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: `yarn start migrate down --target ${target}`,
+          command: `yarn workspace @botpress/messaging-server start migrate down --target ${target}`,
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -140,7 +140,7 @@ describe('Migration CLI', () => {
 
       await startMessagingServer(
         {
-          command: `yarn start migrate up --target ${target}`,
+          command: `yarn workspace @botpress/messaging-server start migrate up --target ${target}`,
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -156,7 +156,7 @@ describe('Migration CLI', () => {
     async () => {
       await startMessagingServer(
         {
-          command: 'yarn start migrate down',
+          command: 'yarn workspace @botpress/messaging-server start migrate down',
           launchTimeout: TIMEOUT
         },
         CLI_MIGRATIONS
@@ -176,7 +176,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn start migrate down --target ${target}`,
+            command: `yarn workspace @botpress/messaging-server start migrate down --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS
@@ -197,7 +197,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn start migrate up --target ${target}`,
+            command: `yarn workspace @botpress/messaging-server start migrate up --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS
@@ -218,7 +218,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn start migrate up --target ${target}`,
+            command: `yarn workspace @botpress/messaging-server start migrate up --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS
@@ -238,7 +238,7 @@ describe('Migration CLI', () => {
       await expect(
         startMessagingServer(
           {
-            command: `yarn start migrate up --target ${target}`,
+            command: `yarn workspace @botpress/messaging-server start migrate up --target ${target}`,
             launchTimeout: TIMEOUT
           },
           CLI_MIGRATIONS

--- a/packages/studio/frontend/src/index.tsx
+++ b/packages/studio/frontend/src/index.tsx
@@ -37,3 +37,5 @@ void axios.get<object>(`${STUDIO_API_URL}${window.location.pathname}/env`).then(
     document.getElementById('app')
   )
 })
+
+console.log('okokokok')

--- a/packages/studio/frontend/src/index.tsx
+++ b/packages/studio/frontend/src/index.tsx
@@ -37,5 +37,3 @@ void axios.get<object>(`${STUDIO_API_URL}${window.location.pathname}/env`).then(
     document.getElementById('app')
   )
 })
-
-console.log('okokokok')

--- a/packages/studio/frontend/src/views/CodeEditor/components/SplashScreen.tsx
+++ b/packages/studio/frontend/src/views/CodeEditor/components/SplashScreen.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { KeyboardShortcut, SplashScreen } from '../../../components/Shared/Interface'
 import { lang } from '../../../components/Shared/translations'
 
-import style from '../style.module.scss'
+import * as style from '../style.module.scss'
 
 export default ({ hasRawPermissions, isAdvanced, setAdvanced }) => (
   <SplashScreen

--- a/test/setup/server.ts
+++ b/test/setup/server.ts
@@ -9,7 +9,7 @@ export const setupServer = async () => {
 
   await setupDevServer({
     debug,
-    command: 'yarn dev',
+    command: 'yarn workspace @botpress/messaging-server dev',
     launchTimeout: 30000,
     protocol: 'http',
     host: '127.0.0.1',


### PR DESCRIPTION
This PR:
 - Make sure that we point to the right folders in the workflows related to the webchat.
 - Convert the yarn build script that used to point to the messaging-server package to call it directly.
 - Updated the test job to only run when needed.