### PR TITLE
chore(studio): use port 3300 for studio server

### DIFF
--- a/packages/studio/frontend/src/index.tsx
+++ b/packages/studio/frontend/src/index.tsx
@@ -15,7 +15,7 @@ import { keyMap } from './components/Shared/utilities/keyboardShortcuts'
 import store from './store'
 import { initializeTranslations } from './translations'
 
-const STUDIO_API_URL = 'http://localhost:3000'
+const STUDIO_API_URL = 'http://localhost:3300'
 
 void axios.get<object>(`${STUDIO_API_URL}${window.location.pathname}/env`).then((d) => {
   for (const [key, value] of Object.entries(d.data)) {

--- a/packages/studio/server/src/studio/server.ts
+++ b/packages/studio/server/src/studio/server.ts
@@ -142,7 +142,7 @@ export class HTTPServer {
         enabled: true
       },
       host: 'localhost',
-      port: 3000,
+      port: 3300,
       externalUrl: null,
       backlog: 100
     }


### PR DESCRIPTION
Self-explanatory. We don't want the port of the runtime and studio server to conflict.