### PR TITLE
chore(studio): re-add testing router

### DIFF
--- a/packages/studio/server/src/studio/studio-router.ts
+++ b/packages/studio/server/src/studio/studio-router.ts
@@ -16,6 +16,7 @@ import MediaRouter from './media/media-router'
 import { NLURouter, NLUService } from './nlu'
 import { QNARouter } from './qna'
 import { HTTPServer } from './server'
+import { TestingRouter } from './testing'
 
 export interface StudioServices {
   logger: Logger
@@ -48,7 +49,7 @@ export class StudioRouter extends CustomRouter {
   private configRouter: ConfigRouter
   private nluRouter: NLURouter
   private qnaRouter: QNARouter
-  // private testingRouter: TestingRouter
+  private testingRouter: TestingRouter
   private manageRouter: ManageRouter
   private codeEditorRouter: CodeEditorRouter
   private cloudRouter: CloudRouter
@@ -70,7 +71,7 @@ export class StudioRouter extends CustomRouter {
     this.configRouter = new ConfigRouter(studioServices)
     this.nluRouter = new NLURouter(studioServices)
     this.qnaRouter = new QNARouter(studioServices)
-    // this.testingRouter = new TestingRouter(studioServices)
+    this.testingRouter = new TestingRouter(studioServices)
     this.manageRouter = new ManageRouter(studioServices)
     this.codeEditorRouter = new CodeEditorRouter(studioServices)
     this.cloudRouter = new CloudRouter(studioServices)
@@ -84,7 +85,7 @@ export class StudioRouter extends CustomRouter {
     this.configRouter.setupRoutes()
     this.nluRouter.setupRoutes()
     this.qnaRouter.setupRoutes()
-    // this.testingRouter.setupRoutes()
+    this.testingRouter.setupRoutes()
     this.manageRouter.setupRoutes()
     this.codeEditorRouter.setupRoutes()
     this.cloudRouter.setupRoutes()
@@ -110,7 +111,7 @@ export class StudioRouter extends CustomRouter {
     this.router.use('/cms', this.checkTokenHeader, this.cmsRouter.router)
     this.router.use('/nlu', this.checkTokenHeader, this.nluRouter.router)
     this.router.use('/qna', this.checkTokenHeader, this.qnaRouter.router)
-    // this.router.use('/testing', this.checkTokenHeader, this.testingRouter.router)
+    this.router.use('/testing', this.checkTokenHeader, this.testingRouter.router)
     this.router.use('/flows', this.checkTokenHeader, this.flowsRouter.router)
     this.router.use('/media', this.mediaRouter.router)
     this.router.use('/hints', this.checkTokenHeader, this.hintsRouter.router)

--- a/packages/studio/server/src/studio/testing/index.ts
+++ b/packages/studio/server/src/studio/testing/index.ts
@@ -1,0 +1,2 @@
+export * from './testing-router'
+export * from './testing-service'

--- a/packages/studio/server/src/studio/testing/recorder.ts
+++ b/packages/studio/server/src/studio/testing/recorder.ts
@@ -1,0 +1,83 @@
+import * as sdk from '@botpress/sdk'
+import _ from 'lodash'
+
+import { Scenario } from './typings'
+import { convertLastMessages } from './utils'
+
+export class Recorder {
+  private _lastEvent?: sdk.IO.IncomingEvent
+  private _scenario?: Scenario
+  private _target?: string
+
+  constructor(private logger: sdk.Logger) {}
+
+  async processIncoming(event: sdk.IO.IncomingEvent): Promise<void> {
+    if (!this.isRecording() || this._scenario?.initialState || !this._target) {
+      return
+    }
+
+    // TODO: This should most likely be a call to the runtime
+    const target = ''
+    //const target = await getMappingFromVisitor(this.database, this.logger, event.botId, this._target)
+    if (target === event.target) {
+      this._scenario!.initialState = event.state
+    }
+  }
+
+  async processCompleted(event: sdk.IO.IncomingEvent): Promise<void> {
+    if (!this.isRecording() || !this._target) {
+      return
+    }
+
+    // TODO: This should most likely be a call to the runtime
+    const target = ''
+    //const target = await getMappingFromVisitor(this.database, this.logger, event.botId, this._target)
+    if (target !== event.target) {
+      return
+    }
+
+    const interactions = convertLastMessages(event.state.session.lastMessages, event.id)
+    if (interactions) {
+      this._lastEvent = event
+      this._scenario!.steps!.push(interactions)
+    }
+  }
+
+  startRecording(chatUserId: string) {
+    this._lastEvent = undefined
+    this._scenario = {
+      initialState: undefined,
+      finalState: undefined,
+      steps: []
+    }
+
+    this._target = chatUserId
+  }
+
+  stopRecording(): Scenario | undefined {
+    if (!this._scenario || !this._lastEvent) {
+      return
+    }
+
+    const finalScenario = {
+      ..._.pick(this._scenario, ['steps', 'initialState']),
+      finalState: this._lastEvent.state
+    }
+
+    this._target = undefined
+    this._scenario = undefined
+
+    return _.omit(finalScenario, [
+      'initialState.session.lastMessages',
+      'initialState.context.jumpPoints',
+      'initialState.context.queue',
+      'finalState.session.lastMessages',
+      'finalState.context.jumpPoints',
+      'finalState.context.queue'
+    ]) as Scenario
+  }
+
+  isRecording() {
+    return !!this._scenario
+  }
+}

--- a/packages/studio/server/src/studio/testing/runner.ts
+++ b/packages/studio/server/src/studio/testing/runner.ts
@@ -1,0 +1,164 @@
+import axios from 'axios'
+import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
+
+import { DialogStep, RunningScenario, Scenario, ScenarioMismatch, ScenarioStatus, Status } from './typings'
+import { convertLastMessages } from './utils'
+
+const SCENARIO_TIMEOUT = 3000
+const CHECK_SCENARIO_TIMEOUT_INTERVAL = 5000
+
+export class ScenarioRunner {
+  private _active: RunningScenario[]
+  private _status: ScenarioStatus
+  private _interval: NodeJS.Timeout | undefined
+
+  constructor() {
+    this._active = []
+    this._status = {}
+  }
+
+  startReplay() {
+    this._status = {}
+    this._active = []
+    this._interval = setInterval(this._checkScenarioTimeout.bind(this), CHECK_SCENARIO_TIMEOUT_INTERVAL)
+  }
+
+  processIncoming(event: sdk.IO.IncomingEvent): sdk.IO.EventState | undefined {
+    if (!this._active.length) {
+      return undefined
+    }
+
+    const scenario = this._active.find((x) => x.eventDestination.target === event.target)
+    if (scenario && !scenario.completedSteps.length) {
+      // The hook will replace the state with the one received here
+      return scenario.initialState
+    }
+  }
+
+  processCompleted(event: sdk.IO.IncomingEvent) {
+    if (!this._active.length) {
+      return
+    }
+
+    const scenario = this._active.find((x) => x.eventDestination.target === event.target)
+    if (!scenario) {
+      return
+    }
+
+    const { name, completedSteps, steps } = scenario
+
+    const conversation = convertLastMessages(event.state.session.lastMessages, event.id)
+    if (!conversation) {
+      this._failScenario(name, { reason: 'Could not extract messages for the event ' + event.id })
+      return
+    }
+
+    const mismatch = this._findMismatch(steps[completedSteps.length], conversation)
+    if (mismatch) {
+      return this._failScenario(name, mismatch)
+    } else {
+      completedSteps.push(conversation)
+      this._updateStatus(name, { completedSteps: completedSteps.length })
+    }
+
+    if (steps.length !== completedSteps.length) {
+      scenario.lastEventTs = +new Date()
+      this._sendMessage(steps[completedSteps.length].userMessage, scenario.eventDestination)
+    } else {
+      this._passScenario(name)
+    }
+  }
+
+  runScenario(scenario: Scenario, eventDestination: sdk.IO.EventDestination) {
+    const firstMessage = scenario.steps?.[0].userMessage
+    if (!firstMessage || !scenario.name) {
+      return
+    }
+
+    this._active.push({ ...scenario, eventDestination, completedSteps: [] } as RunningScenario)
+    this._sendMessage(firstMessage, eventDestination)
+    this._updateStatus(scenario.name, { status: 'pending', completedSteps: 0 })
+  }
+
+  getStatus(scenarioName: string): Status | undefined {
+    return this._status?.[scenarioName]
+  }
+
+  isRunning(): boolean {
+    return !!this._active.length
+  }
+
+  private _findMismatch(expected: DialogStep, received: DialogStep): ScenarioMismatch | undefined {
+    let mismatch: { reason: string; expected: DialogStep; received: DialogStep; index?: number } | undefined = undefined
+
+    // This shouldn't happen
+    if (!expected || !received || expected.userMessage !== received.userMessage) {
+      return { reason: 'Expected or received step was invalid', expected, received }
+    }
+
+    // Inside each steps, the bot may reply multiple times
+    _.each(_.zip(expected.botReplies, received.botReplies), ([exp, rec], idx) => {
+      // This can happen if the bot doesn't respond
+      if (!exp || !rec) {
+        mismatch = { reason: 'Missing an expected or received reply', expected, received, index: idx }
+        return false
+      }
+
+      const sameSource = exp.replySource === rec.replySource
+      const sameResponse = exp.botResponse === rec.botResponse
+      const source = exp.replySource.split(' ').shift() // extracting the first part (module) for the reply
+
+      /**
+       * Different sources are definitely not what is expected
+       * If QNA has the exact same source, then we don't care about the response (variations)
+       * If the source is Dialog Manager, then the answer must be identical (either payload or content element id)
+       */
+      if (!sameSource || (source !== 'qna' && source === 'dialogManager' && !sameResponse)) {
+        mismatch = { reason: 'The reply was invalid', expected, received, index: idx }
+        return false
+      }
+    })
+
+    return mismatch
+  }
+
+  private _checkScenarioTimeout() {
+    if (!this._active.length) {
+      this._interval && clearInterval(this._interval)
+      return
+    }
+
+    const now = +new Date()
+    const mismatch = { reason: 'The scenario timed out' }
+    this._active
+      .filter((s) => s.lastEventTs !== undefined && now - s.lastEventTs > SCENARIO_TIMEOUT)
+      .map((x) => this._failScenario(x.name, mismatch))
+  }
+
+  private _passScenario(name: string) {
+    this._updateStatus(name, { status: 'pass' })
+    this._active = this._active.filter((x) => x.name !== name)
+  }
+
+  private _failScenario(name: string, mismatch: ScenarioMismatch) {
+    this._updateStatus(name, { status: 'fail', mismatch })
+    this._active = this._active.filter((x) => x.name !== name)
+  }
+
+  private _updateStatus(scenario: string, obj: Partial<Status>) {
+    this._status[scenario] = { ...(this._status[scenario] || {}), ...obj }
+  }
+
+  private _sendMessage = (message: string, eventDestination: sdk.IO.EventDestination) => {
+    const { CORE_PORT, ROOT_PATH } = process.core_env
+
+    void axios.post(
+      `http://localhost:${CORE_PORT}${ROOT_PATH}/api/v1/bots/${eventDestination.botId}/converse/${eventDestination.target}`,
+      {
+        type: 'text',
+        text: message
+      }
+    )
+  }
+}

--- a/packages/studio/server/src/studio/testing/runner.ts
+++ b/packages/studio/server/src/studio/testing/runner.ts
@@ -1,5 +1,5 @@
+import * as sdk from '@botpress/sdk'
 import axios from 'axios'
-import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
 import { DialogStep, RunningScenario, Scenario, ScenarioMismatch, ScenarioStatus, Status } from './typings'

--- a/packages/studio/server/src/studio/testing/testing-router.ts
+++ b/packages/studio/server/src/studio/testing/testing-router.ts
@@ -1,0 +1,150 @@
+import * as sdk from '@botpress/sdk'
+import _ from 'lodash'
+import { StudioServices } from '../studio-router'
+
+import { CustomStudioRouter } from '../utils/custom-studio-router'
+import { TestingService } from '.'
+
+export class TestingRouter extends CustomStudioRouter {
+  private testingService = new TestingService(this.logger)
+
+  constructor(services: StudioServices) {
+    super('Testing', services.logger, services.nlu)
+    this.setupRoutes()
+  }
+
+  setupRoutes() {
+    const router = this.router
+
+    router.get(
+      '/scenarios',
+      this.asyncMiddleware(async (req, res) => {
+        const scenarios = await this.testingService.forBot(req.params.botId).getScenarios()
+        const status = this.testingService.forBot(req.params.botId).getState()
+
+        res.send({ scenarios, status })
+      })
+    )
+
+    router.post(
+      '/deleteScenario',
+      this.asyncMiddleware(async (req, res) => {
+        if (!req.body.name) {
+          return res.sendStatus(400)
+        }
+
+        await this.testingService.forBot(req.params.botId).deleteScenario(req.body.name)
+
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/runAll',
+      this.asyncMiddleware(async (req, res) => {
+        await this.testingService.forBot(req.params.botId).executeAll()
+
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/run',
+      this.asyncMiddleware(async (req, res) => {
+        await this.testingService.forBot(req.params.botId).executeSingle(req.body.scenario)
+
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/startRecording',
+      this.asyncMiddleware(async (req, res) => {
+        if (!req.body.userId) {
+          return res.sendStatus(400)
+        }
+
+        await this.testingService.forBot(req.params.botId).startRecording(req.body.userId)
+
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/stopRecording',
+      this.asyncMiddleware(async (req, res) => {
+        const scenario = this.testingService.forBot(req.params.botId).endRecording()
+
+        res.send(scenario)
+      })
+    )
+
+    router.post(
+      '/saveScenario',
+      this.asyncMiddleware(async (req, res) => {
+        const { name, steps } = req.body
+        if (!name || !steps || !name.length) {
+          return res.sendStatus(400)
+        }
+
+        await this.testingService.forBot(req.params.botId).saveScenario(name, steps)
+
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/buildScenario',
+      this.asyncMiddleware(async (req, res) => {
+        const scenario = await this.testingService.forBot(req.params.botId).buildScenario(req.body.eventIds)
+
+        res.send(scenario)
+      })
+    )
+
+    router.post(
+      '/deleteAllScenarios',
+      this.asyncMiddleware(async (req, res) => {
+        await this.testingService.forBot(req.params.botId).deleteAllScenarios()
+
+        return res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/incomingEvent',
+      this.asyncMiddleware(async (req, res) => {
+        const event = req.body as sdk.IO.IncomingEvent
+
+        const eventState = await this.testingService.forBot(req.params.botId).processIncomingEvent(event)
+
+        res.send(eventState)
+      })
+    )
+
+    router.post(
+      '/processedEvent',
+      this.asyncMiddleware(async (req, res) => {
+        const event = req.body as sdk.IO.IncomingEvent
+
+        await this.testingService.forBot(req.params.botId).processCompletedEvent(event)
+
+        return res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/fetchPreviews',
+      this.asyncMiddleware(async (req, res) => {
+        const { elementIds } = req.body
+        if (!elementIds || !_.isArray(elementIds)) {
+          return res.sendStatus(400)
+        }
+
+        const previews = await this.testingService.forBot(req.params.botId).fetchPreviews(elementIds)
+
+        res.send(previews)
+      })
+    )
+  }
+}

--- a/packages/studio/server/src/studio/testing/testing-service.ts
+++ b/packages/studio/server/src/studio/testing/testing-service.ts
@@ -1,0 +1,232 @@
+import * as sdk from '@botpress/sdk'
+import { nanoid } from 'nanoid'
+import path from 'path'
+import { Instance } from '../utils/bpfs'
+
+import { Recorder } from './recorder'
+import { ScenarioRunner } from './runner'
+import { Preview, Scenario, State, Status } from './typings'
+import { buildScenarioFromEvents } from './utils'
+
+const SCENARIO_FOLDER = 'scenarios'
+const TEST_COMPLETION_TIMEOUT = 2000
+
+export class TestingService {
+  private _scopedTestingServices: Map<string, ScopedTestingServiceService> = new Map()
+
+  constructor(private logger: sdk.Logger) {}
+
+  forBot(botId: string): ScopedTestingServiceService {
+    if (this._scopedTestingServices.has(botId)) {
+      return this._scopedTestingServices.get(botId)!
+    }
+
+    const scopedTestingService = new ScopedTestingServiceService(botId, this.logger)
+
+    this._scopedTestingServices.set(botId, scopedTestingService)
+    return scopedTestingService
+  }
+}
+
+export class ScopedTestingServiceService {
+  private _recorder: Recorder
+  private _runner: ScenarioRunner
+  private _scenarios: Scenario[]
+  private _interval?: NodeJS.Timeout
+
+  constructor(private _botId: string, private _logger: sdk.Logger) {
+    this._recorder = new Recorder(this._logger)
+    this._runner = new ScenarioRunner()
+    this._scenarios = []
+  }
+
+  async startRecording(chatUserId: string): Promise<void> {
+    await this._ensureHooksEnabled()
+
+    this._recorder.startRecording(chatUserId)
+  }
+
+  endRecording(): Scenario | undefined {
+    return this._recorder.stopRecording()
+  }
+
+  getState(): State {
+    return {
+      recording: this._recorder.isRecording(),
+      running: this._runner.isRunning()
+    }
+  }
+
+  async getScenarios(): Promise<(Scenario & Status)[]> {
+    if (!this._scenarios.length) {
+      await this._loadScenarios()
+    }
+
+    return this._scenarios.map(({ name, steps }) => {
+      return {
+        name,
+        steps,
+        ...(this._runner.getStatus(name!) || {})
+      }
+    })
+  }
+
+  async processIncomingEvent(event: sdk.IO.IncomingEvent): Promise<sdk.IO.EventState | undefined> {
+    await this._recorder.processIncoming(event)
+
+    return this._runner.processIncoming(event)
+  }
+
+  async processCompletedEvent(event: sdk.IO.IncomingEvent): Promise<void> {
+    await this._recorder.processCompleted(event)
+
+    return this._runner.processCompleted(event)
+  }
+
+  async buildScenario(eventIds: string[]) {
+    const events = await this._findEvents(eventIds)
+
+    if (events.length !== eventIds.length) {
+      throw new Error(
+        `Could not load some specified events. Expected ${eventIds.length}, got ${events.length} events. Maybe they were cleared from the database, or they weren't saved yet.`
+      )
+    }
+
+    return buildScenarioFromEvents(events)
+  }
+
+  async saveScenario(name: string, scenario: Scenario): Promise<void> {
+    await Instance.upsertFile(path.join(SCENARIO_FOLDER, `${name}.json`), JSON.stringify(scenario, undefined, 2))
+
+    await this._loadScenarios()
+  }
+
+  async deleteScenario(name: string): Promise<void> {
+    const filePath = path.join(SCENARIO_FOLDER, `${name}.json`)
+    const exists = await Instance.fileExists(filePath)
+
+    if (!exists) {
+      return
+    }
+
+    await Instance.deleteFile(filePath)
+    await this._loadScenarios()
+  }
+
+  async deleteAllScenarios(): Promise<void[]> {
+    const scenarios = await this.getScenarios()
+
+    return Promise.all(
+      scenarios.map(async (scenario) => {
+        await this.deleteScenario(scenario.name!)
+      })
+    )
+  }
+
+  async executeSingle(liteScenario: Partial<Scenario>): Promise<void> {
+    await this._ensureHooksEnabled()
+    this._runner.startReplay()
+
+    const scenario: Scenario = await Instance.readFile(path.join(SCENARIO_FOLDER, `${liteScenario.name}.json`)).then(
+      (buf) => JSON.parse(buf.toString())
+    )
+
+    return this._executeScenario({ ...liteScenario, ...scenario })
+  }
+
+  async executeAll(): Promise<void> {
+    await this._ensureHooksEnabled()
+    const scenarios = await this._loadScenarios()
+    this._runner.startReplay()
+
+    for (const scenario of scenarios) {
+      this._executeScenario(scenario)
+    }
+  }
+
+  async fetchPreviews(elementIds: string[]): Promise<Preview[]> {
+    // TODO: This should probably be a call to the runtime
+    const elements: any[] = []
+    /* const elements = await this._cms.getContentElements(
+      this._botId,
+      elementIds.map((x) => x.replace('#!', ''))
+    ) */
+
+    return elements.map((element) => {
+      return {
+        id: `#!${element.id}`,
+        preview: element.previews['en'] // TODO: Use the bot's default language instead of hardcoded english
+      }
+    })
+  }
+
+  private async _ensureHooksEnabled(): Promise<void> {
+    if (!this._interval) {
+      this._interval = setInterval(this._waitTestCompletion.bind(this), TEST_COMPLETION_TIMEOUT)
+    }
+
+    try {
+      // TODO: This should be done on the runtime?
+      //await Instance.renameFile('/hooks/before_incoming_middleware/testing/', '.00_recorder.js', '00_recorder.js')
+      //await Instance.renameFile('/hooks/after_event_processed/testing/', '.00_recorder.js', '00_recorder.js')
+    } catch {
+      // Silently fail
+    }
+  }
+
+  private async _waitTestCompletion(): Promise<void> {
+    if (!this._runner.isRunning() && !this._recorder.isRecording()) {
+      try {
+        // TODO: This should be done on the runtime?
+        //await Instance.renameFile('/hooks/before_incoming_middleware/testing/', '00_recorder.js', '.00_recorder.js')
+        //await Instance.renameFile('/hooks/after_event_processed/testing/', '00_recorder.js', '.00_recorder.js')
+      } catch {
+        // Silently fail
+      }
+
+      this._interval && clearInterval(this._interval)
+      this._interval = undefined
+    }
+  }
+
+  private _executeScenario(scenario: Scenario) {
+    const eventDestination: sdk.IO.EventDestination = {
+      channel: 'testing',
+      botId: this._botId,
+      target: `test_${nanoid()}`
+    }
+
+    this._runner.runScenario({ ...scenario }, eventDestination)
+  }
+
+  private async _loadScenarios(): Promise<Scenario[]> {
+    const files = await Instance.directoryListing(SCENARIO_FOLDER, {})
+
+    this._scenarios = []
+    for (const file of files) {
+      const name = path.basename(file as string, '.json')
+      const scenarioSteps = (await Instance.readFile(path.join(SCENARIO_FOLDER, file)).then((buf) =>
+        JSON.parse(buf.toString())
+      )) as Scenario[]
+
+      this._scenarios.push({ name, ...scenarioSteps })
+    }
+
+    return this._scenarios
+  }
+
+  private async _findEvents(eventIds: string[]): Promise<sdk.IO.StoredEvent[]> {
+    /* return this._database('events')
+      .whereIn('incomingEventId', eventIds)
+      .andWhere({ direction: 'incoming' })
+      .then((rows) =>
+        rows.map((storedEvent) => ({
+          ...storedEvent,
+          event: this._database.json.get(storedEvent.event)
+        }))
+      ) */
+
+    // TODO: This should most likely be a call to the runtime
+    return []
+  }
+}

--- a/packages/studio/server/src/studio/testing/typings.ts
+++ b/packages/studio/server/src/studio/testing/typings.ts
@@ -1,0 +1,52 @@
+import * as sdk from 'botpress/sdk'
+
+export interface Scenario {
+  name?: string
+  initialState?: sdk.IO.EventState
+  finalState?: sdk.IO.EventState
+  steps?: DialogStep[]
+}
+
+export type RunningScenario = {
+  eventDestination: sdk.IO.EventDestination
+  lastEventTs?: number
+  completedSteps: DialogStep[]
+} & Required<Scenario>
+
+export interface Status {
+  status?: 'pass' | 'fail' | 'pending'
+  mismatch?: ScenarioMismatch
+  completedSteps?: number
+}
+
+export interface ScenarioStatus {
+  [scenarioName: string]: Status
+}
+
+export interface ScenarioMismatch {
+  reason?: string
+  expected?: DialogStep
+  received?: DialogStep
+  index?: number
+}
+
+export interface DialogStep {
+  userMessage: string
+  botReplies: BotReply[]
+}
+
+export interface BotReply {
+  // TODO: Figure out what typing the response can be in case of QnAs
+  botResponse?: string | { text: string }
+  replySource: string
+}
+
+export interface Preview {
+  id: string
+  preview: string
+}
+
+export interface State {
+  recording: boolean
+  running: boolean
+}

--- a/packages/studio/server/src/studio/testing/typings.ts
+++ b/packages/studio/server/src/studio/testing/typings.ts
@@ -1,4 +1,4 @@
-import * as sdk from 'botpress/sdk'
+import * as sdk from '@botpress/sdk'
 
 export interface Scenario {
   name?: string

--- a/packages/studio/server/src/studio/testing/utils.ts
+++ b/packages/studio/server/src/studio/testing/utils.ts
@@ -1,0 +1,72 @@
+import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
+import { DialogStep, Scenario } from './typings'
+
+export const convertLastMessages = (
+  lastMessages: sdk.IO.DialogTurnHistory[],
+  eventId?: string
+): DialogStep | undefined => {
+  if (!lastMessages) {
+    return undefined
+  }
+  const lastConversation = eventId ? lastMessages.filter((x) => x.eventId === eventId) : lastMessages
+
+  if (!lastConversation.length) {
+    return undefined
+  }
+
+  return {
+    userMessage: lastConversation[0].incomingPreview,
+    botReplies: lastConversation.map((x) => {
+      return {
+        botResponse: x.replyPreview,
+        replySource: x.replySource
+      }
+    })
+  }
+}
+
+export const buildScenarioFromEvents = (events: sdk.IO.StoredEvent[]): Scenario => {
+  const scenario: Partial<Scenario> = {
+    steps: [],
+    // Since we don't have the real initial state (beforeIncomingMiddleware), we force a new one
+    initialState: undefined,
+    finalState: (_.last(events)?.event as sdk.IO.IncomingEvent).state
+  }
+
+  for (const event of events) {
+    const incoming = event.event as sdk.IO.IncomingEvent
+
+    const interactions = convertLastMessages(incoming.state.session.lastMessages, event.incomingEventId)
+    if (interactions) {
+      scenario.steps!.push(interactions)
+    }
+  }
+
+  return _.omit(scenario, [
+    'finalState.session.lastMessages',
+    'finalState.context.jumpPoints',
+    'finalState.context.queue'
+  ])
+}
+
+export const getMappingFromVisitor = async (
+  database: sdk.KnexExtended,
+  logger: sdk.Logger,
+  botId: string,
+  visitorId: string
+): Promise<string | undefined> => {
+  try {
+    const rows = await database('web_user_map').where({ botId, visitorId })
+
+    if (rows?.length) {
+      const mapping = rows[0]
+
+      return mapping.userId
+    }
+  } catch (err) {
+    logger.error('An error occurred while fetching a visitor mapping.', err)
+
+    return undefined
+  }
+}

--- a/packages/studio/server/src/studio/testing/utils.ts
+++ b/packages/studio/server/src/studio/testing/utils.ts
@@ -1,4 +1,4 @@
-import * as sdk from 'botpress/sdk'
+import * as sdk from '@botpress/sdk'
 import _ from 'lodash'
 import { DialogStep, Scenario } from './typings'
 


### PR DESCRIPTION
This PR re-adds the testing module backend to the Studio Server. 

As you will see, I added a lot of TODOs and commented out some pieces of code. This is because we will need to have some ways of querying the runtime to fetch this missing info. I don't think, for example, that the studio should have a direct connection to the runtime's database.