### PR TITLE
feat(messenger): allow receiving file content elements

### DIFF
--- a/packages/channels/src/messenger/api.ts
+++ b/packages/channels/src/messenger/api.ts
@@ -67,6 +67,13 @@ export class MessengerApi extends ChannelApi<MessengerService> {
           text: message.message.text,
           payload: message.message.quick_reply.payload
         })
+      } else if (message.message.attachments) {
+        for (const attachment of message.message.attachments) {
+          await this.service.receive(scope, this.extractEndpoint(message), {
+            type: attachment.type,
+            [attachment.type]: attachment.payload.url
+          })
+        }
       } else {
         await this.service.receive(scope, this.extractEndpoint(message), { type: 'text', text: message.message.text })
       }

--- a/packages/channels/src/messenger/messenger.ts
+++ b/packages/channels/src/messenger/messenger.ts
@@ -17,6 +17,7 @@ export interface MessengerMessage {
     mid: string
     text: string
     quick_reply?: { payload: string }
+    attachments?: { type: string; payload: { url: string } }[]
   }
   postback?: {
     mid: string


### PR DESCRIPTION
This PR adds support for receiving file content-elements (audio, video, images, pdf, etc...) with Messenger _(channel v1.0.0 only)._