### PR TITLE
chore(ci_cd): allow releasing messaging LTS (v.1.2) versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - v1.2
 jobs:
   release_bin:
     if: "${{ startsWith(github.event.head_commit.message, 'chore(server): release v') == true }}"


### PR DESCRIPTION
This PR adds the v1.2 branch as a trigger for releasing a new version of messaging LTS (v.1.2.X)