### PR TITLE
chore(messaging-server): remove spinned env var

### DIFF
--- a/packages/base/engine/src/logger/types.ts
+++ b/packages/base/engine/src/logger/types.ts
@@ -75,8 +75,7 @@ export class Logger {
 
   private center(text: string, width: number) {
     const indent =
-      (yn(process.env.SPINNED) ? 12 : 0) +
-      (!yn(process.env.SPINNED) && yn(process.env.CLUSTER_ENABLED) ? `[${RedisSubservice.nodeId}] `.length : 0) +
+      (yn(process.env.CLUSTER_ENABLED) ? `[${RedisSubservice.nodeId}] `.length : 0) +
       (yn(process.env.DISABLE_LOGGING_TIMESTAMP) ? 0 : 24) +
       1 +
       this.scope.length
@@ -100,9 +99,7 @@ export class Logger {
     }
 
     let title = this.scope
-    if (yn(process.env.SPINNED)) {
-      title = `[Messaging] ${title}`
-    } else if (yn(process.env.CLUSTER_ENABLED)) {
+    if (yn(process.env.CLUSTER_ENABLED)) {
       title = `[${RedisSubservice.nodeId}] ${title}`
     }
 

--- a/packages/messaging/server/src/base/streamer.ts
+++ b/packages/messaging/server/src/base/streamer.ts
@@ -70,7 +70,7 @@ export class Streamer {
     const webhooks = await this.webhooks.list(clientId)
 
     for (const webhook of webhooks) {
-      void this.send(process.env.SPINNED_URL || webhook.url, payload, {
+      void this.send(webhook.url, payload, {
         'x-bp-messaging-client-id': clientId,
         'x-bp-messaging-webhook-token': webhook.token
       })
@@ -97,7 +97,7 @@ export class Streamer {
         jitter: 'none',
         numOfAttempts: MAX_ATTEMPTS,
         retry: (e: AxiosError, attemptNumber: number) => {
-          if (attemptNumber === 1 && (e.response?.status !== 503 || !yn(process.env.SPINNED))) {
+          if (attemptNumber === 1) {
             this.logWebhookError(e, url, 'Failed to send webhook event on first attempt. Retrying 9 more times')
           }
           return !this.destroyed

--- a/packages/messaging/server/src/global.ts
+++ b/packages/messaging/server/src/global.ts
@@ -1,14 +1,9 @@
 import { FrameworkEnv } from '@botpress/messaging-framework'
 
 export type MessagingEnv = FrameworkEnv & {
-  SYNC?: string
-  SPINNED?: string
-  SPINNED_URL?: string
-  NO_LAZY_LOADING?: string
   TWILIO_TESTING?: string
   BILLING_ENDPOINT?: string
   ENABLE_BILLING_STATS?: string
-  DISABLE_SOCKETS?: string
 }
 
 declare global {

--- a/packages/messaging/server/src/instances/invalidation/service.ts
+++ b/packages/messaging/server/src/instances/invalidation/service.ts
@@ -1,6 +1,5 @@
 import { uuid } from '@botpress/messaging-base'
 import { Service } from '@botpress/messaging-engine'
-import yn from 'yn'
 import { ChannelService } from '../../channels/service'
 import { ConduitEvents } from '../../conduits/events'
 import { ConduitService } from '../../conduits/service'
@@ -10,8 +9,6 @@ import { StatusService } from '../../status/service'
 import { InstanceLifetimeService } from '../lifetime/service'
 
 export class InstanceInvalidationService extends Service {
-  private lazyLoadingEnabled!: boolean
-
   constructor(
     private channels: ChannelService,
     private providers: ProviderService,
@@ -23,8 +20,6 @@ export class InstanceInvalidationService extends Service {
   }
 
   async setup() {
-    this.lazyLoadingEnabled = !yn(process.env.NO_LAZY_LOADING)
-
     this.conduits.events.on(ConduitEvents.Created, this.onConduitCreated.bind(this))
     this.conduits.events.on(ConduitEvents.Deleting, this.onConduitDeleting.bind(this))
     this.conduits.events.on(ConduitEvents.Updated, this.onConduitUpdated.bind(this))
@@ -39,7 +34,7 @@ export class InstanceInvalidationService extends Service {
       await this.lifetimes.initialize(conduitId)
     }
 
-    if (!channel.meta.lazy || !this.lazyLoadingEnabled) {
+    if (!channel.meta.lazy) {
       await this.lifetimes.start(conduit.id)
     }
   }
@@ -60,7 +55,7 @@ export class InstanceInvalidationService extends Service {
       await this.lifetimes.initialize(conduitId)
     }
 
-    if (!channel.meta.lazy || !this.lazyLoadingEnabled) {
+    if (!channel.meta.lazy) {
       await this.lifetimes.start(conduit.id)
     }
   }

--- a/packages/messaging/server/src/instances/monitoring/service.ts
+++ b/packages/messaging/server/src/instances/monitoring/service.ts
@@ -1,8 +1,5 @@
 import { DistributedService, Logger, Service } from '@botpress/messaging-engine'
 import ms from 'ms'
-import yn from 'yn'
-import { ChannelService } from '../../channels/service'
-import { ConduitService } from '../../conduits/service'
 import { StatusService } from '../../status/service'
 import { InstanceLifetimeService, MAX_ALLOWED_FAILURES } from '../lifetime/service'
 
@@ -13,8 +10,6 @@ export class InstanceMonitoringService extends Service {
 
   constructor(
     private distributed: DistributedService,
-    private channels: ChannelService,
-    private conduits: ConduitService,
     private status: StatusService,
     private lifetimes: InstanceLifetimeService,
     private logger: Logger
@@ -36,7 +31,6 @@ export class InstanceMonitoringService extends Service {
     try {
       await this.distributed.using('lock_instance_monitoring', async () => {
         await this.initializeOutdatedConduits()
-        await this.loadNonLazyConduits()
       })
     } catch (e) {
       this.logger.error(e, 'Error occurred while monitoring', (e as Error).message)
@@ -46,35 +40,9 @@ export class InstanceMonitoringService extends Service {
   }
 
   private async initializeOutdatedConduits() {
-    if (yn(process.env.SPINNED)) {
-      return
-    }
-
     const outdateds = await this.status.listOutdated(ms('10h'), MAX_ALLOWED_FAILURES, MAX_INITIALIZE_BATCH)
     for (const outdated of outdateds) {
       await this.lifetimes.initialize(outdated.conduitId)
-    }
-  }
-
-  private async loadNonLazyConduits() {
-    if (!yn(process.env.SPINNED)) {
-      return
-    }
-
-    for (const channel of this.channels.list()) {
-      if (channel.meta.lazy && !yn(process.env.NO_LAZY_LOADING)) {
-        continue
-      }
-
-      const conduits = await this.conduits.listByChannel(channel.meta.id)
-      for (const conduit of conduits) {
-        const failures = (await this.status.fetch(conduit.id))?.numberOfErrors || 0
-        if (failures >= MAX_ALLOWED_FAILURES) {
-          continue
-        }
-
-        await this.lifetimes.start(conduit.id)
-      }
     }
   }
 }

--- a/packages/messaging/server/src/instances/service.ts
+++ b/packages/messaging/server/src/instances/service.ts
@@ -78,14 +78,7 @@ export class InstanceService extends Service {
       this.lifetimes
     )
     this.clearing = new InstanceClearingService(caching, channels, providers, conduits, this.lifetimes, this.logger)
-    this.monitoring = new InstanceMonitoringService(
-      this.distributed,
-      this.channels,
-      this.conduits,
-      this.status,
-      this.lifetimes,
-      this.logger
-    )
+    this.monitoring = new InstanceMonitoringService(this.distributed, this.status, this.lifetimes, this.logger)
     this.sandbox = new InstanceSandboxService(this.clients, this.mapping, this.messaging)
   }
 

--- a/packages/messaging/server/src/rewire.ts
+++ b/packages/messaging/server/src/rewire.ts
@@ -5,11 +5,7 @@ if (process.env.TS_NODE_DEV) {
   const originalRequire = Module.prototype.require as (id: string) => any
 
   const rewire = function (this: (id: string) => any, mod: string) {
-    if (
-      mod.startsWith('@botpress/messaging') &&
-      // we don't want to rewire the legacy channels because we get them from npm
-      mod !== '@botpress/messaging-channels-legacy'
-    ) {
+    if (mod.startsWith('@botpress/messaging')) {
       return originalRequire.apply(this, [mod + '/src'])
     }
     return originalRequire.apply(this, [mod])

--- a/packages/messaging/server/src/socket/manager.ts
+++ b/packages/messaging/server/src/socket/manager.ts
@@ -24,10 +24,6 @@ export class SocketManager {
   ) {}
 
   async setup(server: Server) {
-    if (yn(process.env.DISABLE_SOCKETS)) {
-      return
-    }
-
     this.ws = new Socket.Server(server, { serveClient: false, cors: { origin: '*' } })
     this.ws.use(this.handleSocketAuthentication.bind(this))
     this.ws.on('connection', this.handleSocketConnection.bind(this))


### PR DESCRIPTION
Since the messaging server does not get "spinned" by botpress anymore, I removed the dead code related to that setting