### PR TITLE
chore(ci_cd): allow manually releasing a new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,12 @@ on:
   push:
     branches:
       - master
+      - v1.2
+  workflow_dispatch:
+
 jobs:
   release_bin:
-    if: "${{ startsWith(github.event.head_commit.message, 'chore(server): release v') == true }}"
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(server): release v') == true || github.event_name == 'workflow_dispatch'  }}"
     name: Release Binaries
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Self-explanatory. We want to be able to manually release a new version and allow to release versions from the v1.2 branch.