### PR TITLE
chore(yarn): remove unnecessary log outputs

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,11 +1,51 @@
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: "@yarnpkg/plugin-workspace-tools"
+    spec: '@yarnpkg/plugin-workspace-tools'
   - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
-    spec: "@yarnpkg/plugin-version"
+    spec: '@yarnpkg/plugin-version'
   - path: .yarn/plugins/@yarnpkg/plugin-engines.cjs
-    spec: "https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js"
+    spec: 'https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js'
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
+
+logFilters:
+  # List of codes: https://yarnpkg.com/advanced/error-codes
+  #
+  # EXCEPTION - An exception had be thrown by the program.
+  - code: 'YN0001'
+    level: 'error'
+  # MISSING_PEER_DEPENDENCY - A package requests a peer dependency, but one or more of its parents in the dependency tree doesn't provide it.
+  - code: 'YN0002'
+    level: 'discard'
+  # CYCLIC_DEPENDENCIES - Two packages with build scripts have cyclic dependencies.
+  - code: 'YN0003'
+    level: 'error'
+  # DISABLED_BUILD_SCRIPTS - A package has build scripts, but they've been disabled across the project.
+  - code: 'YN0004'
+    level: 'error'
+  # BUILD_DISABLED - A package has build scripts, but they've been disabled through its configuration.
+  - code: 'YN0005'
+    level: 'discard'
+  # SOFT_LINK_BUILD - A package has build scripts, but is linked through a soft link.
+  - code: 'YN0006'
+    level: 'discard'
+  # MUST_BUILD - A package must be built.
+  - code: 'YN0007'
+    level: 'discard'
+  # MUST_REBUILD - A package must be rebuilt.
+  - code: 'YN0008'
+    level: 'discard'
+  # BUILD_FAILED - A package build failed.
+  - code: 'YN0009'
+    level: 'error'
+  # FETCH_NOT_CACHED - A package cannot be found in the cache for the given package and will be fetched from its remote location.
+  - code: 'YN0013'
+    level: 'discard'
+  # UNUSED_CACHE_ENTRY - A file from the cache has been detected unused while installing dependencies.
+  - code: 'YN0019'
+    level: 'discard'
+  # INCOMPATIBLE_PEER_DEPENDENCY - A package requests a peer dependency, but its parent in the dependency tree provides a version that does not satisfy the peer dependency's range.
+  - code: 'YN0060'
+    level: 'discard'
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs


### PR DESCRIPTION
This PR removes some verbose logging from yarn commands like printing all the warnings about peer dependencies, build, cache entries, etc.

To test this PR, run `yarn` after upgrading a package, adding a new one, removing a package, adding one that does not exist, etc.