### PR TITLE
chore(server): increase max payload size to 150kb

### DIFF
--- a/packages/framework/src/routes.ts
+++ b/packages/framework/src/routes.ts
@@ -29,7 +29,7 @@ export class Routes {
         allowedHeaders: '*'
       })
     )
-    this.router.use(express.json({ limit: '100kb' }))
+    this.router.use(express.json({ limit: '150kb' }))
     this.router.use(express.urlencoded({ extended: true }))
   }
 

--- a/packages/server/test/security/api.test.ts
+++ b/packages/server/test/security/api.test.ts
@@ -6,7 +6,7 @@ import froth from './mocha-froth'
 
 const UUID_LENGTH = uuid().length
 const TOKEN_LENGTH = 125
-const MAX_PAYLOAD_SIZE = 100 * 1024 * 1024 // ~100kb
+const MAX_PAYLOAD_SIZE = 150 * 1024 * 1024 // ~150kb
 const FAKE_CLIENT_ID = uuid()
 const FAKE_CLIENT_TOKEN = froth(TOKEN_LENGTH, TOKEN_LENGTH, {
   none: false,


### PR DESCRIPTION
Self-explanatory!

Note that we don't care if the max payload size is 100kb or 150kb as long as it's a reasonable size for text payloads. 150kb is also the max payload size of MS Teams.