### PR TITLE
feat(webchat): allow to react on message click

### DIFF
--- a/packages/webchat/src/components/messages/MessageGroup.tsx
+++ b/packages/webchat/src/components/messages/MessageGroup.tsx
@@ -49,7 +49,13 @@ class MessageGroup extends React.Component<Props> {
       >
         {avatar}
         <div role="region" className={'bpw-message-container'}>
-          <div aria-live="assertive" role="log" className={'bpw-message-group'}>
+          <div
+            aria-live="assertive"
+            role="log"
+            className={classnames('bpw-message-group', {
+              'bpw-message-group-selected': !!this.props.messages.find((m) => m.id === this.props.selectedMessageId)
+            })}
+          >
             <span data-from={fromLabel} className="from hidden" aria-hidden="true">
               {fromLabel}
             </span>
@@ -96,7 +102,8 @@ class MessageGroup extends React.Component<Props> {
 export default inject(({ store }: { store: RootStore }) => ({
   store,
   sendFeedback: store.sendFeedback,
-  sendData: store.sendData
+  sendData: store.sendData,
+  selectedMessageId: store.selectedMessageId
 }))(MessageGroup)
 
 type Props = {
@@ -105,4 +112,4 @@ type Props = {
   messages: MessageDetails[]
   isLastGroup: boolean
   store?: RootStore
-} & Pick<StoreDef, 'sendFeedback' | 'sendData'>
+} & Pick<StoreDef, 'sendFeedback' | 'sendData' | 'selectedMessageId'>

--- a/packages/webchat/src/core/socket.tsx
+++ b/packages/webchat/src/core/socket.tsx
@@ -1,5 +1,6 @@
 import { Message, MessagingSocket, UserCredentials } from '@botpress/messaging-socket'
 import { Config } from '../typings'
+import { postMessageToParent } from '../utils/webchatEvents'
 
 export default class BpSocket {
   public socket: MessagingSocket
@@ -24,10 +25,6 @@ export default class BpSocket {
     return message
   }
 
-  public postToParent = (_type: string, payload: any) => {
-    window.parent?.postMessage({ ...payload, chatId: this.chatId }, '*')
-  }
-
   public async connect(): Promise<void> {
     const creds = this.getCreds()
     await this.socket.connect(creds)
@@ -36,7 +33,7 @@ export default class BpSocket {
       const userId = this.socket.userId!
       window.BP_STORAGE.set('creds', this.socket.creds)
 
-      this.postToParent('', { userId })
+      postMessageToParent('userConnected', { userId }, this.chatId)
     }
   }
 

--- a/packages/webchat/src/main.tsx
+++ b/packages/webchat/src/main.tsx
@@ -15,6 +15,7 @@ import { RootStore, StoreDef } from './store'
 import { Config, Message } from './typings'
 import { isIE } from './utils'
 import { initializeAnalytics, trackMessage, trackWebchatState } from './utils/analytics'
+import { postMessageToParent } from './utils/webchatEvents'
 
 export const DEFAULT_TYPING_DELAY = 1000
 
@@ -102,7 +103,7 @@ class Web extends React.Component<MainProps> {
     }
 
     if (this.config.containerWidth) {
-      this.postMessageToParent('setWidth', this.config.containerWidth)
+      postMessageToParent('setWidth', this.config.containerWidth, this.config.chatId)
     }
 
     await this.props.fetchBotInfo!()
@@ -112,10 +113,6 @@ class Web extends React.Component<MainProps> {
     }
 
     this.setupObserver()
-  }
-
-  postMessageToParent(type: string, value: any) {
-    window.parent?.postMessage({ type, value, chatId: this.config.chatId }, '*')
   }
 
   extractConfig(): Config {
@@ -150,7 +147,7 @@ class Web extends React.Component<MainProps> {
   setupObserver() {
     observe(this.props.dimensions!, 'container', (data) => {
       if (data.newValue) {
-        this.postMessageToParent('setWidth', data.newValue)
+        postMessageToParent('setWidth', data.newValue, this.config.chatId)
       }
     })
   }
@@ -170,6 +167,7 @@ class Web extends React.Component<MainProps> {
   }
 
   handleIframeApi = async ({ data }: IframeAPIData) => {
+    console.log('handleIframeApi', data)
     switch (data.action) {
       case 'configure':
         return this.props.updateConfig!(Object.assign({}, constants.DEFAULT_CONFIG, data.payload))
@@ -295,7 +293,7 @@ class Web extends React.Component<MainProps> {
     })
 
     if (this.parentClass !== parentClass) {
-      this.postMessageToParent('setClass', parentClass)
+      postMessageToParent('setClass', parentClass, this.config.chatId)
       this.parentClass = parentClass
     }
 

--- a/packages/webchat/src/main.tsx
+++ b/packages/webchat/src/main.tsx
@@ -167,7 +167,6 @@ class Web extends React.Component<MainProps> {
   }
 
   handleIframeApi = async ({ data }: IframeAPIData) => {
-    console.log('handleIframeApi', data)
     switch (data.action) {
       case 'configure':
         return this.props.updateConfig!(Object.assign({}, constants.DEFAULT_CONFIG, data.payload))

--- a/packages/webchat/src/store/view.ts
+++ b/packages/webchat/src/store/view.ts
@@ -4,6 +4,7 @@ import { action, computed, observable, runInAction } from 'mobx'
 import constants from '../core/constants'
 import { ChatDimensions, CustomAction, CustomButton } from '../typings'
 
+import { postMessageToParent } from '../utils/webchatEvents'
 import { RootStore } from '.'
 
 class ViewStore {
@@ -179,7 +180,7 @@ class ViewStore {
   @action.bound
   setLoadingCompleted() {
     this._isLoading = false
-    this.rootStore.postMessage('webchatLoaded')
+    postMessageToParent('webchatLoaded', undefined, this.rootStore.config.chatId)
   }
 
   @action.bound
@@ -247,7 +248,7 @@ class ViewStore {
   showChat() {
     if (this.disableAnimations) {
       this.activeView = 'side'
-      this.rootStore.postMessage('webchatOpened')
+      postMessageToParent('webchatOpened', undefined, this.rootStore.config.chatId)
       return this._updateTransitions({ widgetTransition: undefined, sideTransition: 'none' })
     }
 
@@ -259,7 +260,7 @@ class ViewStore {
 
     this._endAnimation('side')
 
-    this.rootStore.postMessage('webchatOpened')
+    postMessageToParent('webchatOpened', undefined, this.rootStore.config.chatId)
   }
 
   @action.bound
@@ -270,7 +271,7 @@ class ViewStore {
 
     if (this.disableAnimations) {
       this.activeView = 'widget'
-      this.rootStore.postMessage('webchatClosed')
+      postMessageToParent('webchatClosed', undefined, this.rootStore.config.chatId)
       return this._updateTransitions({ widgetTransition: undefined, sideTransition: undefined })
     }
 
@@ -284,7 +285,7 @@ class ViewStore {
 
     this._endAnimation('widget')
 
-    this.rootStore.postMessage('webchatClosed')
+    postMessageToParent('webchatClosed', undefined, this.rootStore.config.chatId)
   }
 
   @action.bound

--- a/packages/webchat/src/utils/webchatEvents.ts
+++ b/packages/webchat/src/utils/webchatEvents.ts
@@ -1,5 +1,3 @@
 export const postMessageToParent = (type: string, value: any, chatId?: string) => {
-  console.log('value', value)
-  console.log('data', { type, value, chatId })
   window.parent?.postMessage({ type, value, chatId }, '*')
 }

--- a/packages/webchat/src/utils/webchatEvents.ts
+++ b/packages/webchat/src/utils/webchatEvents.ts
@@ -1,0 +1,5 @@
+export const postMessageToParent = (type: string, value: any, chatId?: string) => {
+  console.log('value', value)
+  console.log('data', { type, value, chatId })
+  window.parent?.postMessage({ type, value, chatId }, '*')
+}


### PR DESCRIPTION
This PR allows the developer to react to message click on the webchat. When a user clicks on any message, an event (`messageClicked`) is sent to the parent windows (the HTML page that embeds the webchat) that contains the message details.