### PR TITLE
feat(telegram): allow receiving file/audio/video/image

### DIFF
--- a/packages/channels/src/telegram/README.md
+++ b/packages/channels/src/telegram/README.md
@@ -24,8 +24,8 @@
 | Postback      |    ✅    |         |
 | Say Something |    ✅    |         |
 | Voice         |    ❌    |         |
-| Image         |    ❌    |         |
-| File          |    ❌    |         |
-| Audio         |    ❌    |         |
-| Video         |    ❌    |         |
+| Image         |    ✅    |         |
+| File          |    ✅    |         |
+| Audio         |    ✅    |         |
+| Video         |    ✅    |         |
 | Location      |    ❌    |         |


### PR DESCRIPTION
This PR adds support for receiving files (file/audio/video/image) with Telegram (channel v1.0.0 only).

Similar to: https://github.com/botpress/messaging/pull/480