### PR TITLE
fix(messenger): allow buttonless card

### DIFF
--- a/packages/channels/src/messenger/messenger.ts
+++ b/packages/channels/src/messenger/messenger.ts
@@ -30,7 +30,7 @@ export interface MessengerCard {
   title: string
   image_url?: string
   subtitle?: string
-  buttons: MessengerButton[]
+  buttons?: MessengerButton[]
 }
 
 export interface MessengerButton {

--- a/packages/channels/src/messenger/renderers/carousel.ts
+++ b/packages/channels/src/messenger/renderers/carousel.ts
@@ -45,19 +45,11 @@ export class MessengerCarouselRenderer extends CarouselRenderer {
   }
 
   endRenderCard(context: Context, card: CardContent) {
-    if (context.buttons.length === 0) {
-      context.buttons.push({
-        type: 'postback',
-        title: card.title,
-        payload: card.title
-      })
-    }
-
     context.cards.push({
       title: card.title,
       image_url: card.image ? card.image : undefined,
       subtitle: card.subtitle,
-      buttons: context.buttons
+      ...(context.buttons?.length && { buttons: context.buttons })
     })
   }
 


### PR DESCRIPTION
Today it's impossible to have a card without a button; this PR fixes it. I believe that before, it was not allowed because you can't send an empty button list, if you do, the card is not displayed on Messenger; my PR will make sure that there is at least one button before creating the property.