### PR TITLE
fix(socket): don't send userdata=undefined

### DIFF
--- a/packages/socket/src/socket.ts
+++ b/packages/socket/src/socket.ts
@@ -42,10 +42,8 @@ export class MessagingSocket extends SocketEmitter<{
   }
 
   async connect(creds?: UserCredentials, userData?: UserData): Promise<UserCredentials> {
-    const result = await this.com.connect(
-      { clientId: this.clientId, creds },
-      { userData: userData ? JSON.stringify(userData) : undefined }
-    )
+    const query = userData ? { userData: JSON.stringify(userData) } : undefined
+    const result = await this.com.connect({ clientId: this.clientId, creds }, query)
 
     if (result.userId === creds?.userId && !result.userToken) {
       result.userToken = creds!.userToken


### PR DESCRIPTION
Fixes an issue where sending `?userData=undefined` was being sent when opening the socket.
This results in unexpected user updates here https://github.com/botpress/messaging/blob/cae0d2dc0e366a2708a1e4704f4d16a3956e9c56/packages/server/src/socket/manager.ts#L108

because `_.isEqual('undefined', undefined) === false`