### PR TITLE
fixes issue on dark theme

### DIFF
--- a/packages/inject/src/inject.css
+++ b/packages/inject/src/inject.css
@@ -13,6 +13,7 @@
   letter-spacing: 0;
   -webkit-font-smoothing: antialiased;
   padding: 0;
+  color-scheme: none;
 }
 
 .bp-widget-widget {


### PR DESCRIPTION
The issue is described here. https://linear.app/botpress/issue/QA-1175/widget-has-white-background

A few people have this issue. This was even a problem on botpress.com/docs