### PR TITLE
fix(webchat): increase conversation history length

### DIFF
--- a/packages/webchat/src/core/api.tsx
+++ b/packages/webchat/src/core/api.tsx
@@ -42,7 +42,7 @@ export default class WebchatApi {
     try {
       const conversation = await this.socket.socket.getConversation(conversationId)
       this.socket.socket.switchConversation(conversation!.id)
-      const messages = (await this.socket.socket.listMessages()).filter((x) => x.payload.type !== 'visit')
+      const messages = (await this.socket.socket.listMessages(500)).filter((x) => x.payload.type !== 'visit')
       return { ...conversation, messages }
     } catch (err) {
       console.error('Error fetching a conversation', err)


### PR DESCRIPTION
Conversation history currently defaults to the 20 last messages in the webchat. Until we make this configurable to users through the studio, let's increase the limit to something much less limiting, as many use-cases (such as ed-tech) require the history to be present for returning users (over multiple days).