### PR TITLE
fix: typo in theme-light

### DIFF
--- a/packages/inject/src/themes/theme-light.css
+++ b/packages/inject/src/themes/theme-light.css
@@ -75,7 +75,7 @@
   border-radius: 0;
 }
 
-@media (max-width: 480px) {
+@media (min-width: 480px) {
   .bpw-layout {
     margin-right: var(--space-from-corner);
     margin-bottom: var(--space-from-corner);


### PR DESCRIPTION
the mobile css code was shown in desktop (max-width instead of min-width), this fixes that.