### PR TITLE
fix: update GH_TOKEN permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   release_bin:
+    permissions:
+      contents: write
     if: "${{ startsWith(github.event.head_commit.message, 'chore(server): release v') == true || github.event_name == 'workflow_dispatch'  }}"
     name: Release Binaries
     runs-on: ubuntu-latest


### PR DESCRIPTION
Token isn't allowed to write any content anymore as we changed our default GH_TOKEN permissions for botpress org