### PR TITLE
fix(webchat): make html escaping configurable

### DIFF
--- a/packages/webchat/src/components/messages/Message.tsx
+++ b/packages/webchat/src/components/messages/Message.tsx
@@ -68,7 +68,7 @@ class Message extends Component<MessageProps> {
           onAudioEnded: this.props.onAudioEnded,
           shouldPlay: this.props.shouldPlay,
           intl: this.props.store!.intl,
-          escapeHTML: true,
+          escapeHTML: this.props.store!.config.escapeHtml === undefined ? true : this.props.store!.config.escapeHtml,
           showTimestamp: this.props.store!.config.showTimestamp!,
           googleMapsAPIKey: this.props.store!.config.googleMapsAPIKey
         }}

--- a/packages/webchat/src/typings.ts
+++ b/packages/webchat/src/typings.ts
@@ -376,6 +376,12 @@ export interface Config {
    * Display's the webchat close button when the webchat is opened
    */
   showCloseButton?: boolean
+  /**
+   * Replaces < and > with their HTML entities &lt; and &gt;.
+   * Setting it to false will let the markdown parser handle html itself
+   * @default true
+   */
+  escapeHtml?: boolean
 }
 
 export interface BotDetails {


### PR DESCRIPTION
We use markdown-it to display content, when html is escaped it breaks some of the feature (with backticks it would display &lt; instead of <).

This makes it configurable so its backward compatible 