### PR TITLE
chore: publish new messaging socket client

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,46 @@
+name: Publish Messaging Packages
+on: workflow_dispatch
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install
+        run: |
+          yarn --immutable
+      - name: Build Client
+        working-directory: ./packages/client
+        run: |
+          yarn build
+      - name: Build Socket
+        working-directory: ./packages/socket
+        run: |
+          yarn build
+      - name: Build Webchat
+        working-directory: ./packages/webchat
+        run: |
+          yarn build
+      - name: Publish Client
+        uses: botpress/gh-actions/publish-if-not-exists@master
+        with:
+          path: './packages/client'
+          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
+      - name: Publish Socket
+        uses: botpress/gh-actions/publish-if-not-exists@master
+        with:
+          path: './packages/socket'
+          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
+      - name: Publish Webchat
+        uses: botpress/gh-actions/publish-if-not-exists@master
+        with:
+          path: './packages/webchat'
+          token: '${{ secrets.NPM_ACCESS_TOKEN }}'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@botpress/messaging-base": "1.2.0",
     "@botpress/messaging-client": "1.2.1",
-    "@botpress/messaging-socket": "1.2.0",
+    "@botpress/messaging-socket": "1.3.0",
     "@botpress/webchat": "0.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -19,7 +19,7 @@
     "@botpress/messaging-base": "1.2.0",
     "@botpress/messaging-client": "1.2.1",
     "@botpress/messaging-socket": "1.3.0",
-    "@botpress/webchat": "0.5.1",
+    "@botpress/webchat": "0.5.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -27,7 +27,7 @@
     "ts-node": "^10.9.1"
   },
   "dependencies": {
-    "@botpress/webchat": "0.5.1",
+    "@botpress/webchat": "0.5.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/messaging-socket",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/packages/webchat/package.json
+++ b/packages/webchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/webchat",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.tsx",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@blueprintjs/core": "^3.23.1",
     "@botpress/messaging-components": "0.4.3",
-    "@botpress/messaging-socket": "1.2.0",
+    "@botpress/messaging-socket": "1.3.0",
     "@formatjs/intl-pluralrules": "^4.1.6",
     "@formatjs/intl-utils": "^3.8.4",
     "@juggle/resize-observer": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,7 +2189,7 @@ __metadata:
   dependencies:
     "@botpress/messaging-base": 1.2.0
     "@botpress/messaging-client": 1.2.1
-    "@botpress/messaging-socket": 1.2.0
+    "@botpress/messaging-socket": 1.3.0
     "@botpress/webchat": 0.5.1
     "@parcel/config-default": ^2.2.1
     "@parcel/transformer-typescript-tsc": ^2.2.1
@@ -2468,7 +2468,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/messaging-socket@1.2.0, @botpress/messaging-socket@workspace:packages/socket":
+"@botpress/messaging-socket@1.3.0, @botpress/messaging-socket@workspace:packages/socket":
   version: 0.0.0-use.local
   resolution: "@botpress/messaging-socket@workspace:packages/socket"
   dependencies:
@@ -2482,6 +2482,16 @@ __metadata:
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
+
+"@botpress/messaging-socket@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@botpress/messaging-socket@npm:1.2.0"
+  dependencies:
+    "@botpress/messaging-base": 1.2.0
+    socket.io-client: ^4.4.1
+  checksum: 01b38fa0b5f8bc8b094c2205f767b5c42bacd099335bd7bf634e885de8aa24d15c4976f28803aa409674014fce4fcd7a0adbc9db77f8c71fe2ccce88761746a3
+  languageName: node
+  linkType: hard
 
 "@botpress/messaging@workspace:.":
   version: 0.0.0-use.local
@@ -2564,13 +2574,44 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/webchat@0.5.1, @botpress/webchat@workspace:packages/webchat":
+"@botpress/webchat@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@botpress/webchat@npm:0.5.1"
+  dependencies:
+    "@blueprintjs/core": ^3.23.1
+    "@botpress/messaging-components": 0.4.3
+    "@botpress/messaging-socket": 1.2.0
+    "@formatjs/intl-pluralrules": ^4.1.6
+    "@formatjs/intl-utils": ^3.8.4
+    "@juggle/resize-observer": ^3.0.2
+    axios: ^0.25.0
+    classnames: ^2.3.1
+    crypto-js: ^4.1.1
+    date-fns: ^1.30.1
+    js-cookie: ^3.0.1
+    lodash: ^4.17.21
+    mime: ^3.0.0
+    mobx: 5.15.7
+    mobx-react: ^6.2.1
+    query-string: ^7.1.0
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-ga: ^2.7.0
+    react-intl: ^3.12.1
+    react-scroll-to-bottom: ^4.2.0
+    snarkdown: ^2.0.0
+    uuid: ^8.3.2
+  checksum: 0be0ebd7295a3df3f42dcf5bd68b125c80aeb8194b5a446bc7380f4016e3aa5c9f9a7c75d28db8d69a29f7fd56a2f595d480e567dd8973e6023b82953ddcecb4
+  languageName: node
+  linkType: hard
+
+"@botpress/webchat@workspace:packages/webchat":
   version: 0.0.0-use.local
   resolution: "@botpress/webchat@workspace:packages/webchat"
   dependencies:
     "@blueprintjs/core": ^3.23.1
     "@botpress/messaging-components": 0.4.3
-    "@botpress/messaging-socket": 1.2.0
+    "@botpress/messaging-socket": 1.3.0
     "@formatjs/intl-pluralrules": ^4.1.6
     "@formatjs/intl-utils": ^3.8.4
     "@juggle/resize-observer": ^3.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,7 +2190,7 @@ __metadata:
     "@botpress/messaging-base": 1.2.0
     "@botpress/messaging-client": 1.2.1
     "@botpress/messaging-socket": 1.3.0
-    "@botpress/webchat": 0.5.1
+    "@botpress/webchat": 0.5.2
     "@parcel/config-default": ^2.2.1
     "@parcel/transformer-typescript-tsc": ^2.2.1
     "@types/react": ^17.0.38
@@ -2483,16 +2483,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/messaging-socket@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@botpress/messaging-socket@npm:1.2.0"
-  dependencies:
-    "@botpress/messaging-base": 1.2.0
-    socket.io-client: ^4.4.1
-  checksum: 01b38fa0b5f8bc8b094c2205f767b5c42bacd099335bd7bf634e885de8aa24d15c4976f28803aa409674014fce4fcd7a0adbc9db77f8c71fe2ccce88761746a3
-  languageName: node
-  linkType: hard
-
 "@botpress/messaging@workspace:.":
   version: 0.0.0-use.local
   resolution: "@botpress/messaging@workspace:."
@@ -2560,7 +2550,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@botpress/webchat-inject@workspace:packages/inject"
   dependencies:
-    "@botpress/webchat": 0.5.1
+    "@botpress/webchat": 0.5.2
     "@parcel/config-default": ^2.2.1
     "@parcel/reporter-bundle-analyzer": 2.2.1
     "@parcel/transformer-typescript-tsc": ^2.2.1
@@ -2574,38 +2564,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/webchat@npm:0.5.1":
-  version: 0.5.1
-  resolution: "@botpress/webchat@npm:0.5.1"
-  dependencies:
-    "@blueprintjs/core": ^3.23.1
-    "@botpress/messaging-components": 0.4.3
-    "@botpress/messaging-socket": 1.2.0
-    "@formatjs/intl-pluralrules": ^4.1.6
-    "@formatjs/intl-utils": ^3.8.4
-    "@juggle/resize-observer": ^3.0.2
-    axios: ^0.25.0
-    classnames: ^2.3.1
-    crypto-js: ^4.1.1
-    date-fns: ^1.30.1
-    js-cookie: ^3.0.1
-    lodash: ^4.17.21
-    mime: ^3.0.0
-    mobx: 5.15.7
-    mobx-react: ^6.2.1
-    query-string: ^7.1.0
-    react: ^17.0.2
-    react-dom: ^17.0.2
-    react-ga: ^2.7.0
-    react-intl: ^3.12.1
-    react-scroll-to-bottom: ^4.2.0
-    snarkdown: ^2.0.0
-    uuid: ^8.3.2
-  checksum: 0be0ebd7295a3df3f42dcf5bd68b125c80aeb8194b5a446bc7380f4016e3aa5c9f9a7c75d28db8d69a29f7fd56a2f595d480e567dd8973e6023b82953ddcecb4
-  languageName: node
-  linkType: hard
-
-"@botpress/webchat@workspace:packages/webchat":
+"@botpress/webchat@0.5.2, @botpress/webchat@workspace:packages/webchat":
   version: 0.0.0-use.local
   resolution: "@botpress/webchat@workspace:packages/webchat"
   dependencies:


### PR DESCRIPTION
There have been some changes in `@botpress/messaging-socket` since the last time it was published. I want to get these changes on npm